### PR TITLE
Avoid adding extra flags to Makefile by default

### DIFF
--- a/spmd_benchMark/Makefile
+++ b/spmd_benchMark/Makefile
@@ -36,9 +36,7 @@ GEN_GPU_SRC	:=				# .cu files
 
 # You can modify these variables, some will be appended to by the runtime makefile
 INC_FLAGS	:= -I ../include/ -I ../include/tasks/
-CC_FLAGS	:= \
-		-DLEGION_IDS_ARE_64BIT \
-
+CC_FLAGS	:=
 NVCC_FLAGS	:=
 GASNET_FLAGS	:=
 

--- a/spmd_benchMark/Makefile
+++ b/spmd_benchMark/Makefile
@@ -54,11 +54,11 @@ LD_FLAGS 	:= -llapack -lblas
 endif
 
 # enable legion spy
-ifeq ($(strip $(DEBUG)),1)
-CC_FLAGS += -DLEGION_SPY \
-	-DPRIVILEGE_CHECKS \
-	-DBOUNDS_CHECKS
-endif
+# ifeq ($(strip $(DEBUG)),1)
+# CC_FLAGS += -DLEGION_SPY \
+# 	-DPRIVILEGE_CHECKS \
+# 	-DBOUNDS_CHECKS
+# endif
 
 # dynamic linking on daint
 ifeq ($(findstring daint,$(shell uname -n)),daint)

--- a/spmd_benchMark/Makefile
+++ b/spmd_benchMark/Makefile
@@ -35,10 +35,10 @@ GEN_SRC	:= 	solver.cc \
 GEN_GPU_SRC	:=				# .cu files
 
 # You can modify these variables, some will be appended to by the runtime makefile
-INC_FLAGS	:= -I ../include/ -I ../include/tasks/
-CC_FLAGS	:=
-NVCC_FLAGS	:=
-GASNET_FLAGS	:=
+INC_FLAGS	?= -I ../include/ -I ../include/tasks/
+CC_FLAGS	?=
+NVCC_FLAGS	?=
+GASNET_FLAGS	?=
 
 ifneq (${CRAYPE_VERSION},)
 # Cray systems include a special version of BLAS and LAPACK which is


### PR DESCRIPTION
This PR includes three changes:

 1. Removes the build flag `LEGION_IDS_ARE_64BIT`. This flag is now obsolete.

 2. Disables by default the addition of Legion Spy on debug mode.

 3. Use `?=` instead of `:=` to define most variables.

The last two make it easier to include this in our Legion test suite, since we need to control these flags via the command line. Otherwise we would need to fork the repo in order to be able to continue testing it.