### PR TITLE
Bring code up to date with new Legion namespace, point/rect, accessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,16 @@
 *.log
 *.gz
 
+# Generated Headers
+legion_defines.h
+realm_defines.h
+
 # Compiled Object files
 *.slo
 *.lo
 *.o
 *.obj
+*.d
 
 # Precompiled Headers
 *.gch

--- a/include/hmatrix.hpp
+++ b/include/hmatrix.hpp
@@ -14,13 +14,13 @@ public:
   // build U * V' + D
   void init
   (const Matrix& U, const Matrix& V, const Vector& D,
-   Context, HighLevelRuntime*);
+   Context, Runtime*);
 
   // fast solver
-  Vector solve(const Matrix& b, Context, HighLevelRuntime*);
+  Vector solve(const Matrix& b, Context, Runtime*);
 
   // destructor
-  void destroy(Context, HighLevelRuntime*);
+  void destroy(Context, Runtime*);
   
 private:
 

--- a/include/lmatrix.hpp
+++ b/include/lmatrix.hpp
@@ -4,8 +4,7 @@
 #include <string>
 
 #include "legion.h"
-using namespace LegionRuntime;
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 #include "utility.hpp" // for WAIT_DEFAULT and FIELDID_V
 #include "matrix.hpp"
@@ -15,14 +14,14 @@ using namespace LegionRuntime::HighLevel;
 class LMatrix {
 public:
   LMatrix();
-  LMatrix(int, int, int, Context, HighLevelRuntime*);
+  LMatrix(int, int, int, Context, Runtime*);
   LMatrix(int, int, LogicalRegion, IndexSpace, FieldSpace);
   LMatrix(LogicalRegion r, int rows, int cols);
 
   /*
   LMatrix
   (int, int, int, IndexPartition ip, LogicalRegion lr,
-   Context, HighLevelRuntime*); // to be removed
+   Context, Runtime*); // to be removed
   */
   ~LMatrix();
   
@@ -46,65 +45,65 @@ public:
   void set_logical_partition(LogicalPartition lp);
   
   // create logical region
-  void create(int, int, Context, HighLevelRuntime*);
+  void create(int, int, Context, Runtime*);
 
   // set the matrix to value
   void clear
-  (double, Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+  (double, Context, Runtime*, bool wait=WAIT_DEFAULT);
 
   // scale all the entries
   void scale
-  (double, Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+  (double, Context, Runtime*, bool wait=WAIT_DEFAULT);
 
   // initialize data from Matrix object
   void init_data
-  (const Matrix& mat, Context, HighLevelRuntime*,
+  (const Matrix& mat, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
 
   // init part of the region
   void init_data
-  (int, int, const Matrix& mat, Context, HighLevelRuntime*,
+  (int, int, const Matrix& mat, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
   
   // output region
-  Matrix to_matrix(Context, HighLevelRuntime*);
-  Matrix to_matrix(int, int, Context, HighLevelRuntime*);
-  Matrix to_matrix(int, int, int, int, Context, HighLevelRuntime*);
+  Matrix to_matrix(Context, Runtime*);
+  Matrix to_matrix(int, int, Context, Runtime*);
+  Matrix to_matrix(int, int, int, int, Context, Runtime*);
 
   // to be removed
   void init_data
-  (int, const Matrix& VMat, Context, HighLevelRuntime*,
+  (int, const Matrix& VMat, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
 
   // specifies column range
   // for UTree init
   void init_data
-  (int, int, int, const Matrix& VMat, Context, HighLevelRuntime*,
+  (int, int, int, const Matrix& VMat, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
   
   // for KTree::partition
   void init_dense_blocks
   (const Matrix& UMat, const Matrix& VMat, const Vector& DVec,
-   Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+   Context, Runtime*, bool wait=WAIT_DEFAULT);
 
   void init_dense_blocks
   (int, int, const Matrix& UMat, const Matrix& VMat, const Vector& DVec,
-   Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+   Context, Runtime*, bool wait=WAIT_DEFAULT);
 
   // uniform partition
   // Note: the first argument is level, NOT nPart
-  void partition(int level, Context, HighLevelRuntime*);
+  void partition(int level, Context, Runtime*);
 
   /*
   // return a new matrix with created partition,
   //  so no need to destroy region twice
   LMatrix partition
   (int level, int col0, int col1,
-   Context ctx, HighLevelRuntime *runtime);
+   Context ctx, Runtime *runtime);
   */
   
   // for node solve
-  void two_level_partition(Context, HighLevelRuntime*);
+  void two_level_partition(Context, Runtime*);
   
   // output the right hand side
   // for UTree::rhs()
@@ -113,60 +112,60 @@ public:
   // for KTree::partition()
   //void create_dense_partition
   //(int, const Matrix& U, const Matrix& V, const Vector& D,
-  //Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+  //Context, Runtime*, bool wait=WAIT_DEFAULT);
   
   // solve linear system
   // for KTree::solve()
   void solve
-  (LMatrix&, LMatrix&, Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+  (LMatrix&, LMatrix&, Context, Runtime*, bool wait=WAIT_DEFAULT);
 
   // solve node system
   // for HMatrix::solve()
   void node_solve
-  (LMatrix&, Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+  (LMatrix&, Context, Runtime*, bool wait=WAIT_DEFAULT);
 
   static void node_solve
   (LMatrix&, LMatrix&, LMatrix&, LMatrix&,
    PhaseBarrier pb_wait, PhaseBarrier pb_ready,
-   Context ctx, HighLevelRuntime* runtime, bool wait=WAIT_DEFAULT);
+   Context ctx, Runtime* runtime, bool wait=WAIT_DEFAULT);
 
   // print the values on screen
   // for debugging
   void display
-  (const std::string&, Context, HighLevelRuntime*,
+  (const std::string&, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
 
   // free resources
-  void clear(Context, HighLevelRuntime*);
+  void clear(Context, Runtime*);
   
   // static methods
   // matrix subtraction
   static void add
   (double alpha, const LMatrix&,
    double beta,  const LMatrix&, LMatrix&,
-   Context, HighLevelRuntime*, bool wait=WAIT_DEFAULT);
+   Context, Runtime*, bool wait=WAIT_DEFAULT);
 
   // gemm reduction
   // C = alpha*op(A) * op(B) + beta*C
   static void gemmRed
   (char, char, double, const LMatrix&, const LMatrix&,
-   double, LMatrix&, Context, HighLevelRuntime*,
+   double, LMatrix&, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
 
   static void gemm
   (char, char, double, const LMatrix&, const LMatrix&,
-   double, LMatrix&, Context, HighLevelRuntime*,
+   double, LMatrix&, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
 
   static void gemm_inplace
   (char, char, double, const LMatrix&, const LMatrix&,
-   double, LMatrix&, Context, HighLevelRuntime*,
+   double, LMatrix&, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
 
   // gemm broadcast
   static void gemmBro
   (char, char, double, const LMatrix&, const LMatrix&,
-   double, LMatrix&, Context, HighLevelRuntime*,
+   double, LMatrix&, Context, Runtime*,
    bool wait=WAIT_DEFAULT);
   
 private:
@@ -186,15 +185,15 @@ private:
 
   // partition the matrix along rows
   IndexPartition UniformRowPartition
-  (Context ctx, HighLevelRuntime *runtime);
+  (Context ctx, Runtime *runtime);
   
   IndexPartition UniformRowPartition
-  (int num_subregions, int, int, Context ctx, HighLevelRuntime *runtime);
+  (int num_subregions, int, int, Context ctx, Runtime *runtime);
 
   /*
   template <typename T>
   void solve
-  (LMatrix& b, Context ctx, HighLevelRuntime *runtime,
+  (LMatrix& b, Context ctx, Runtime *runtime,
    bool wait=WAIT_DEFAULT);
   */
   

--- a/include/tasks/add_matrix.hpp
+++ b/include/tasks/add_matrix.hpp
@@ -2,7 +2,7 @@
 #define _add_matrix_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class AddMatrixTask : public IndexLauncher {
 public:
@@ -28,7 +28,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/clear_matrix.hpp
+++ b/include/tasks/clear_matrix.hpp
@@ -2,7 +2,7 @@
 #define _clear_matrix_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class ClearMatrixTask : public IndexLauncher {
 public:
@@ -27,7 +27,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/dense_block.hpp
+++ b/include/tasks/dense_block.hpp
@@ -3,7 +3,6 @@
 
 #include "legion.h"
 using namespace Legion;
-using namespace LegionRuntime::Accessor;
 
 struct ThreeSeeds {
   long uSeed;

--- a/include/tasks/dense_block.hpp
+++ b/include/tasks/dense_block.hpp
@@ -2,7 +2,7 @@
 #define _dense_block_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 using namespace LegionRuntime::Accessor;
 
 struct ThreeSeeds {
@@ -34,7 +34,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/display_matrix.hpp
+++ b/include/tasks/display_matrix.hpp
@@ -3,7 +3,6 @@
 
 #include "legion.h"
 using namespace Legion;
-using namespace LegionRuntime::Accessor;
 
 #include <string>
 

--- a/include/tasks/display_matrix.hpp
+++ b/include/tasks/display_matrix.hpp
@@ -2,7 +2,7 @@
 #define _display_matrix_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 using namespace LegionRuntime::Accessor;
 
 #include <string>
@@ -29,7 +29,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/dist_mapper.hpp
+++ b/include/tasks/dist_mapper.hpp
@@ -3,11 +3,11 @@
 
 #include "default_mapper.h"
 
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class DistMapper : public DefaultMapper {
 public:
-  DistMapper(Machine machine, HighLevelRuntime *rt,
+  DistMapper(Machine machine, Runtime *rt,
 	     Processor local, int radix_=2);
 public:
   virtual void select_task_options(Task *task);

--- a/include/tasks/gemm.hpp
+++ b/include/tasks/gemm.hpp
@@ -2,7 +2,7 @@
 #define _gemm_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class GemmTask : public TaskLauncher {
 public:
@@ -33,7 +33,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/gemm_broadcast.hpp
+++ b/include/tasks/gemm_broadcast.hpp
@@ -2,7 +2,7 @@
 #define _gemm_broadcast_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class GemmBroTask : public IndexLauncher {
 public:
@@ -34,7 +34,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/gemm_inplace.hpp
+++ b/include/tasks/gemm_inplace.hpp
@@ -2,7 +2,7 @@
 #define _gemm_inplace_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class GemmInplaceTask : public TaskLauncher {
 public:
@@ -31,7 +31,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/gemm_reduce.hpp
+++ b/include/tasks/gemm_reduce.hpp
@@ -2,7 +2,7 @@
 #define _gemm_reduce_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class GemmRedTask : public IndexLauncher {
 public:
@@ -35,7 +35,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/init_matrix.hpp
+++ b/include/tasks/init_matrix.hpp
@@ -3,7 +3,6 @@
 
 #include "legion.h"
 using namespace Legion;
-using namespace LegionRuntime::Accessor;
 
 class InitMatrixTask : public IndexLauncher {
 public:

--- a/include/tasks/init_matrix.hpp
+++ b/include/tasks/init_matrix.hpp
@@ -2,7 +2,7 @@
 #define _init_matrix_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 using namespace LegionRuntime::Accessor;
 
 class InitMatrixTask : public IndexLauncher {
@@ -29,7 +29,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/leaf_solve.hpp
+++ b/include/tasks/leaf_solve.hpp
@@ -2,7 +2,7 @@
 #define _leaf_solve_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class LeafSolveTask : public IndexLauncher {
 public:
@@ -28,7 +28,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/mapper.hpp
+++ b/include/tasks/mapper.hpp
@@ -3,12 +3,12 @@
 
 #include "default_mapper.h"
 
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class SolverMapper : public DefaultMapper {
 public:
   SolverMapper(Machine machine, 
-	       HighLevelRuntime *rt, Processor local);
+	       Runtime *rt, Processor local);
 public:
   virtual void select_task_options(Task *task);
   virtual void slice_domain(const Task *task, const Domain &domain,

--- a/include/tasks/node_solve.hpp
+++ b/include/tasks/node_solve.hpp
@@ -2,7 +2,7 @@
 #define _node_solve_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class NodeSolveTask : public IndexLauncher {
 public:
@@ -24,7 +24,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/node_solve_region.hpp
+++ b/include/tasks/node_solve_region.hpp
@@ -2,7 +2,7 @@
 #define _node_solve_region_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class NodeSolveRegionTask : public TaskLauncher {
 public:
@@ -24,7 +24,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/projector.hpp
+++ b/include/tasks/projector.hpp
@@ -2,14 +2,14 @@
 #define _projector_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 extern const ProjectionID CONTRACTION;
 
 class Contraction : public ProjectionFunctor {
 public:
   
-  Contraction(HighLevelRuntime *runtime);
+  Contraction(Runtime *runtime);
 
   virtual LogicalRegion project(Context ctx, Task *task,
                                 unsigned index,

--- a/include/tasks/reduce_add.hpp
+++ b/include/tasks/reduce_add.hpp
@@ -2,7 +2,7 @@
 #define _reduce_add_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 extern const int REDOP_ADD;
 

--- a/include/tasks/scale_matrix.hpp
+++ b/include/tasks/scale_matrix.hpp
@@ -2,7 +2,7 @@
 #define _scale_matrix_hpp
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class ScaleMatrixTask : public IndexLauncher {
 public:
@@ -27,7 +27,7 @@ public:
   static void
   cpu_task(const Task *task,
 	   const std::vector<PhysicalRegion> &regions,
-	   Context ctx, HighLevelRuntime *runtime);
+	   Context ctx, Runtime *runtime);
 };
 
 #endif

--- a/include/tasks/solver_tasks.hpp
+++ b/include/tasks/solver_tasks.hpp
@@ -26,10 +26,10 @@
 
 void register_solver_tasks();
 
-void create_callback(Machine machine, HighLevelRuntime *rt,
+void create_callback(Machine machine, Runtime *rt,
 		     const std::set<Processor> &local_procs);
 
-void create_projector(Machine machine, HighLevelRuntime *rt,
+void create_projector(Machine machine, Runtime *rt,
 		      const std::set<Processor> &local_procs);
 
 #endif

--- a/include/tasks/spmd_mapper.hpp
+++ b/include/tasks/spmd_mapper.hpp
@@ -4,11 +4,11 @@
 #include "default_mapper.h"
 #include "shim_mapper.h"
 
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 class SPMDsolverMapper : public ShimMapper {
 public:
-  SPMDsolverMapper(Machine machine, HighLevelRuntime *rt, Processor local,
+  SPMDsolverMapper(Machine machine, Runtime *rt, Processor local,
 		   std::vector<Processor>* procs_list,
 		   std::vector<Memory>* sysmems_list,
 		   std::map<Memory, std::vector<Processor> >* sysmem_local_procs,

--- a/include/tree.hpp
+++ b/include/tree.hpp
@@ -11,14 +11,14 @@ public:
   // init data
   void init(const Matrix&);
   
-  void init(int, const Matrix&, Context ctx, HighLevelRuntime *runtime);
+  void init(int, const Matrix&, Context ctx, Runtime *runtime);
   
   // initialize problem right hand side
   void init_rhs
-  (const Vector&, Context ctx, HighLevelRuntime *runtime);
+  (const Vector&, Context ctx, Runtime *runtime);
 
   void init_rhs
-  (const Matrix&, Context ctx, HighLevelRuntime *runtime,
+  (const Matrix&, Context ctx, Runtime *runtime,
    bool wait=false);
   
   // return right hand side (overwritten by solution)
@@ -26,13 +26,13 @@ public:
 
   // create partition
   void partition
-  (int level, Context ctx, HighLevelRuntime *runtime);
+  (int level, Context ctx, Runtime *runtime);
   
   void horizontal_partition
-  (int level, Context ctx, HighLevelRuntime *runtime);
+  (int level, Context ctx, Runtime *runtime);
 
   // return the solution
-  Matrix solution(Context ctx, HighLevelRuntime *runtime);
+  Matrix solution(Context ctx, Runtime *runtime);
   
   // return the legion matrix for one level
   LMatrix& uMat_level(int);
@@ -43,7 +43,7 @@ public:
   // legion matrices at leaf level
   LMatrix& leaf();
 
-  void clear(Context ctx, HighLevelRuntime* runtime);
+  void clear(Context ctx, Runtime* runtime);
   
 private:
   int mLevel;
@@ -69,21 +69,21 @@ public:
   // init data
   void init(const Matrix&);
   
-  void init(int, const Matrix&, Context ctx, HighLevelRuntime *runtime);
+  void init(int, const Matrix&, Context ctx, Runtime *runtime);
 
   // create partition
   void partition
-  (int level, Context ctx, HighLevelRuntime *runtime);
+  (int level, Context ctx, Runtime *runtime);
 
   void horizontal_partition
-  (int level, Context ctx, HighLevelRuntime *runtime);
+  (int level, Context ctx, Runtime *runtime);
 
   // return the legion matrix for one level
   LMatrix& leaf();
   LMatrix& level(int);
   LMatrix& level_new(int);
 
-  void clear(Context ctx, HighLevelRuntime* runtime);
+  void clear(Context ctx, Runtime* runtime);
   
 private:
   int mLevel;
@@ -104,20 +104,20 @@ public:
   void init(const Matrix& U, const Matrix& V, const Vector& D);
 
   void init(int, const Matrix& U, const Matrix& V, const Vector& D,
-	    Context ctx, HighLevelRuntime *runtime);
+	    Context ctx, Runtime *runtime);
 
   // create partition
   void partition
-  (int level, Context ctx, HighLevelRuntime *runtime);
+  (int level, Context ctx, Runtime *runtime);
 
   void horizontal_partition
-  (int level, Context ctx, HighLevelRuntime *runtime);
+  (int level, Context ctx, Runtime *runtime);
 
   // wrapper for legion matrix solve
   // leaf solve task
-  void solve(LMatrix&, LMatrix&, Context ctx, HighLevelRuntime *runtime);
+  void solve(LMatrix&, LMatrix&, Context ctx, Runtime *runtime);
   
-  void clear(Context ctx, HighLevelRuntime* runtime);
+  void clear(Context ctx, Runtime* runtime);
 
 private:
   int mLevel;

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -19,9 +19,9 @@ bool is_power_of_two(int x);
 
 double* region_pointer(const PhysicalRegion &region, int, int, int, int);
 
+template<PrivilegeMode PRIVILEGE>
 PtrMatrix get_raw_pointer
-(const PhysicalRegion &region, int rlo, int rhi, int clo, int chi,
- bool wait=false);
+(const PhysicalRegion &region, int rlo, int rhi, int clo, int chi);
 
 PtrMatrix reduction_pointer
 (const PhysicalRegion &region, int rlo, int rhi, int clo, int chi);

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -6,7 +6,6 @@
 
 #include "legion.h"
 using namespace Legion;
-using namespace LegionRuntime::Accessor;
 
 enum {
   FIELDID_V,

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -5,7 +5,7 @@
 #include "ptr_matrix.hpp"
 
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 using namespace LegionRuntime::Accessor;
 
 enum {

--- a/spmd_driver/Makefile
+++ b/spmd_driver/Makefile
@@ -37,7 +37,7 @@ GEN_GPU_SRC	:=				# .cu files
 
 # You can modify these variables, some will be appended to by the runtime makefile
 INC_FLAGS	?= -I ../include/ -I ../include/tasks/
-CC_FLAGS	?= -std=c++11
+CC_FLAGS	?=
 NVCC_FLAGS	?=
 GASNET_FLAGS	?=
 

--- a/spmd_driver/solver.cc
+++ b/spmd_driver/solver.cc
@@ -4,8 +4,7 @@
 
 // legion stuff
 #include "legion.h"
-using namespace LegionRuntime;
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 #include "matrix.hpp"  // for Matrix  class
 #include "hmatrix.hpp" // for HMatrix class
@@ -34,7 +33,7 @@ bool is_master_task(int point, int current_level, int total_level) {
 }
 
 LMatrix create_local_region(LogicalRegion ghost, int rows, int cols,
-			    Context ctx, HighLevelRuntime *runtime) {
+			    Context ctx, Runtime *runtime) {
   IndexSpace is = ghost.get_index_space();
   FieldSpace fs = runtime->create_field_space(ctx);
   {
@@ -53,7 +52,7 @@ LMatrix create_legion_matrix(LogicalRegion region, int rows, int cols) {
 
 void spmd_fast_solver(const Task *task,
 		      const std::vector<PhysicalRegion> &regions,
-		      Context ctx, HighLevelRuntime *runtime) {
+		      Context ctx, Runtime *runtime) {
 
   char hostname[100];
   gethostname(hostname, 100);
@@ -224,7 +223,7 @@ void spmd_fast_solver(const Task *task,
 
 void top_level_task(const Task *task,
 		    const std::vector<PhysicalRegion> &regions,
-		    Context ctx, HighLevelRuntime *runtime) {
+		    Context ctx, Runtime *runtime) {
  
   // machine configuration
   int num_machines = 1;
@@ -239,7 +238,7 @@ void top_level_task(const Task *task,
   const int nRhs = 1;
 
   // parse input arguments
-  const InputArgs &command_args = HighLevelRuntime::get_input_args();
+  const InputArgs &command_args = Runtime::get_input_args();
   if (command_args.argc > 1) {
     for (int i = 1; i < command_args.argc; i++) {
       if (!strcmp(command_args.argv[i],"-machine"))
@@ -425,8 +424,8 @@ void top_level_task(const Task *task,
 
 int main(int argc, char *argv[]) {
   // register top level task
-  HighLevelRuntime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
-  HighLevelRuntime::register_legion_task<top_level_task>(
+  Runtime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
+  Runtime::register_legion_task<top_level_task>(
     TOP_LEVEL_TASK_ID,   /* task id */
     Processor::LOC_PROC, /* cpu */
     true,  /* single */
@@ -435,7 +434,7 @@ int main(int argc, char *argv[]) {
     TaskConfigOptions(false /*leaf task*/),
     "master-task"
   );
-  HighLevelRuntime::register_legion_task<spmd_fast_solver>(SPMD_TASK_ID,
+  Runtime::register_legion_task<spmd_fast_solver>(SPMD_TASK_ID,
       Processor::LOC_PROC, true/*single*/, true/*single*/,
       AUTO_GENERATE_ID, TaskConfigOptions(false), "spmd");
 
@@ -443,5 +442,5 @@ int main(int argc, char *argv[]) {
   register_solver_tasks();
 
   // start legion master task
-  return HighLevelRuntime::start(argc, argv);
+  return Runtime::start(argc, argv);
 }

--- a/spmd_driver/solver_irregular_part.cc
+++ b/spmd_driver/solver_irregular_part.cc
@@ -441,23 +441,18 @@ void top_level_task(const Task *task,
 int main(int argc, char *argv[]) {
   // register top level task
   Runtime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
-  Runtime::register_legion_task<top_level_task>
-    (TOP_LEVEL_TASK_ID,   /* task id */
-     Processor::LOC_PROC, /* cpu */
-     true,  /* single */
-     false, /* index  */
-     AUTO_GENERATE_ID,
-     TaskConfigOptions(false /*leaf task*/),
-     "master-task");
-  
-  Runtime::register_legion_task<spmd_fast_solver>
-    (SPMD_TASK_ID,
-     Processor::LOC_PROC,
-     true/*single*/,
-     true/*single*/,
-     AUTO_GENERATE_ID,
-     TaskConfigOptions(false),
-     "spmd");
+
+  {
+    TaskVariantRegistrar registrar(TOP_LEVEL_TASK_ID, "master-task");
+    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+    Runtime::preregister_task_variant<top_level_task>(registrar, "cpu");
+  }
+
+  {
+    TaskVariantRegistrar registrar(SPMD_TASK_ID, "spmd");
+    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+    Runtime::preregister_task_variant<spmd_fast_solver>(registrar, "cpu");
+  }
 
   // register solver tasks
   register_solver_tasks();

--- a/spmd_driver/solver_irregular_part.cc
+++ b/spmd_driver/solver_irregular_part.cc
@@ -161,11 +161,11 @@ Context ctx, Runtime *runtime) {
     LogicalRegion VTu_local = VTu.logical_region();
     LogicalRegion VTd_local = VTd.logical_region();
     cp_VTu.add_copy_requirements
-      (RegionRequirement(VTu_local, READ_ONLY, EXCLUSIVE, VTu_local),
-       RegionRequirement(VTu_ghost, REDOP_ADD, EXCLUSIVE, VTu_ghost));
+      (RegionRequirement(VTu_local, LEGION_READ_ONLY, LEGION_EXCLUSIVE, VTu_local),
+       RegionRequirement(VTu_ghost, REDOP_ADD, LEGION_EXCLUSIVE, VTu_ghost));
     cp_VTd.add_copy_requirements
-      (RegionRequirement(VTd_local, READ_ONLY, EXCLUSIVE, VTd_local),
-       RegionRequirement(VTd_ghost, REDOP_ADD, EXCLUSIVE, VTd_ghost));
+      (RegionRequirement(VTd_local, LEGION_READ_ONLY, LEGION_EXCLUSIVE, VTd_local),
+       RegionRequirement(VTd_ghost, REDOP_ADD, LEGION_EXCLUSIVE, VTd_ghost));
     cp_VTu.add_src_field(0, FIELDID_V);
     cp_VTu.add_dst_field(0, FIELDID_V);
     cp_VTd.add_src_field(0, FIELDID_V);
@@ -199,8 +199,8 @@ Context ctx, Runtime *runtime) {
 	runtime->advance_phase_barrier(ctx, args->node_solve[l]);
       CopyLauncher cp_node_solve;
       cp_node_solve.add_copy_requirements
-	(RegionRequirement(VTd_ghost, READ_ONLY, EXCLUSIVE, VTd_ghost),
-	 RegionRequirement(VTd_local, WRITE_DISCARD, EXCLUSIVE, VTd_local));
+	(RegionRequirement(VTd_ghost, LEGION_READ_ONLY, LEGION_EXCLUSIVE, VTd_ghost),
+	 RegionRequirement(VTd_local, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, VTd_local));
       cp_node_solve.add_src_field(0, FIELDID_V);
       cp_node_solve.add_dst_field(0, FIELDID_V);
       cp_node_solve.add_wait_barrier(args->node_solve[l]);
@@ -388,8 +388,8 @@ void top_level_task(const Task *task,
 	for (int i=0; i<2; i++) {
 	  LogicalRegion VTu = VTu_ghosts[idx][i];
 	  LogicalRegion VTd = VTd_ghosts[idx][i];
-	  RegionRequirement VTu_req(VTu,READ_WRITE,SIMULTANEOUS,VTu);
-	  RegionRequirement VTd_req(VTd,READ_WRITE,SIMULTANEOUS,VTd);
+	  RegionRequirement VTu_req(VTu,LEGION_READ_WRITE,LEGION_SIMULTANEOUS,VTu);
+	  RegionRequirement VTd_req(VTd,LEGION_READ_WRITE,LEGION_SIMULTANEOUS,VTd);
 	  VTu_req.add_field(FIELDID_V);
 	  VTd_req.add_field(FIELDID_V);
 	  spmd_tasks[shard].add_region_requirement(VTu_req);
@@ -401,10 +401,10 @@ void top_level_task(const Task *task,
       else {
 	LogicalRegion VTu = VTu_ghosts[idx][subidx];
 	LogicalRegion VTd = VTd_ghosts[idx][subidx];
-	RegionRequirement VTu_req(VTu,READ_WRITE,SIMULTANEOUS,VTu);
-	RegionRequirement VTd_req(VTd,READ_WRITE,SIMULTANEOUS,VTd);
-	VTu_req.flags = NO_ACCESS_FLAG;
-	VTd_req.flags = NO_ACCESS_FLAG;
+	RegionRequirement VTu_req(VTu,LEGION_READ_WRITE,LEGION_SIMULTANEOUS,VTu);
+	RegionRequirement VTd_req(VTd,LEGION_READ_WRITE,LEGION_SIMULTANEOUS,VTd);
+	VTu_req.flags = LEGION_NO_ACCESS_FLAG;
+	VTd_req.flags = LEGION_NO_ACCESS_FLAG;
 	VTu_req.add_field(FIELDID_V);
 	VTd_req.add_field(FIELDID_V);
 	spmd_tasks[shard].add_region_requirement(VTu_req);

--- a/spmd_driver/solver_irregular_ranks.cc
+++ b/spmd_driver/solver_irregular_ranks.cc
@@ -4,7 +4,7 @@
 
 // legion stuff
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 #include "matrix.hpp"  // for Matrix  class
 #include "hmatrix.hpp" // for HMatrix class
@@ -35,7 +35,7 @@ bool is_master_task(int point, int current_level, int total_level) {
 
 /*
 LMatrix create_local_region(LogicalRegion ghost, int rows, int cols,
-			    Context ctx, HighLevelRuntime *runtime) {
+			    Context ctx, Runtime *runtime) {
   IndexSpace is = ghost.get_index_space();
   FieldSpace fs = runtime->create_field_space(ctx);
   {
@@ -50,7 +50,7 @@ LMatrix create_local_region(LogicalRegion ghost, int rows, int cols,
 */
 
 LogicalRegion create_local_region(LogicalRegion ghost,
-			    Context ctx, HighLevelRuntime *runtime) {
+			    Context ctx, Runtime *runtime) {
   IndexSpace is = ghost.get_index_space();
   FieldSpace fs = runtime->create_field_space(ctx);
   {
@@ -66,7 +66,7 @@ LMatrix create_legion_matrix(LogicalRegion region, int rows, int cols) {
 }
 
 LMatrix create_legion_matrix(LogicalRegion region,
-			    Context ctx, HighLevelRuntime *runtime) {
+			    Context ctx, Runtime *runtime) {
   Domain dom = runtime->get_index_space_domain(ctx,region.get_index_space());
   Rect<2> rect = dom.get_rect<2>();
   int rows = rect.dim_size(0);
@@ -76,7 +76,7 @@ LMatrix create_legion_matrix(LogicalRegion region,
 
 void spmd_fast_solver(const Task *task,
 		      const std::vector<PhysicalRegion> &regions,
-		      Context ctx, HighLevelRuntime *runtime) {
+		      Context ctx, Runtime *runtime) {
 
   char hostname[100];
   gethostname(hostname, 100);
@@ -261,7 +261,7 @@ void spmd_fast_solver(const Task *task,
 
 void top_level_task(const Task *task,
 		    const std::vector<PhysicalRegion> &regions,
-		    Context ctx, HighLevelRuntime *runtime) {
+		    Context ctx, Runtime *runtime) {
  
   // machine configuration
   const int num_machines = 2;
@@ -277,7 +277,7 @@ void top_level_task(const Task *task,
   const int nRhs = 1;
 
   // parse input arguments
-  const InputArgs &command_args = HighLevelRuntime::get_input_args();
+  const InputArgs &command_args = Runtime::get_input_args();
   if (command_args.argc > 1) {
     for (int i = 1; i < command_args.argc; i++) {
       //if (!strcmp(command_args.argv[i],"-machine"))
@@ -498,8 +498,8 @@ void top_level_task(const Task *task,
 
 int main(int argc, char *argv[]) {
   // register top level task
-  HighLevelRuntime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
-  HighLevelRuntime::register_legion_task<top_level_task>(
+  Runtime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
+  Runtime::register_legion_task<top_level_task>(
     TOP_LEVEL_TASK_ID,   /* task id */
     Processor::LOC_PROC, /* cpu */
     true,  /* single */
@@ -508,7 +508,7 @@ int main(int argc, char *argv[]) {
     TaskConfigOptions(false /*leaf task*/),
     "master-task"
   );
-  HighLevelRuntime::register_legion_task<spmd_fast_solver>(SPMD_TASK_ID,
+  Runtime::register_legion_task<spmd_fast_solver>(SPMD_TASK_ID,
       Processor::LOC_PROC, true/*single*/, true/*single*/,
       AUTO_GENERATE_ID, TaskConfigOptions(false), "spmd");
 
@@ -516,5 +516,5 @@ int main(int argc, char *argv[]) {
   register_solver_tasks();
 
   // start legion master task
-  return HighLevelRuntime::start(argc, argv);
+  return Runtime::start(argc, argv);
 }

--- a/src/hmatrix.cc
+++ b/src/hmatrix.cc
@@ -21,7 +21,7 @@ HMatrix::HMatrix(int nProc_, int level_)
 
 void HMatrix::init
 (const Matrix& U, const Matrix& V, const Vector& D,
- Context ctx, HighLevelRuntime* runtime) {
+ Context ctx, Runtime* runtime) {
   
   // sanity check
   assert( U.rows() == V.rows() );
@@ -47,7 +47,7 @@ void HMatrix::init
 }
 
 Vector HMatrix::solve
-(const Matrix& b, Context ctx, HighLevelRuntime* runtime) {
+(const Matrix& b, Context ctx, Runtime* runtime) {
 
   // check input
   assert( b.rows() > 0 );

--- a/src/lmatrix.cc
+++ b/src/lmatrix.cc
@@ -184,7 +184,7 @@ Matrix LMatrix::to_matrix(Context ctx, Runtime *runtime) {
   PhysicalRegion region = runtime->map_region(ctx, launcher);
   region.wait_until_valid();
  
-  PtrMatrix pMat = get_raw_pointer(region, 0, mRows, colIdx, colIdx+mCols);
+  PtrMatrix pMat = get_raw_pointer<LEGION_READ_WRITE>(region, 0, mRows, colIdx, colIdx+mCols);
   for (int j=0; j<mCols; j++)
     for (int i=0; i<mRows; i++)
       temp(i, j) = pMat(i, j);
@@ -204,7 +204,7 @@ Matrix LMatrix::to_matrix
   PhysicalRegion region = runtime->map_region(ctx, launcher);
   region.wait_until_valid();
  
-  PtrMatrix pMat = get_raw_pointer(region, 0, mRows, col0, col1);
+  PtrMatrix pMat = get_raw_pointer<LEGION_READ_WRITE>(region, 0, mRows, col0, col1);
   for (int j=0; j<temp.cols(); j++)
     for (int i=0; i<temp.rows(); i++)
       temp(i, j) = pMat(i, j);
@@ -225,7 +225,7 @@ Matrix LMatrix::to_matrix
   PhysicalRegion region = runtime->map_region(ctx, launcher);
   region.wait_until_valid();
  
-  PtrMatrix pMat = get_raw_pointer(region, rlo, rhi, clo, chi);
+  PtrMatrix pMat = get_raw_pointer<LEGION_READ_WRITE>(region, rlo, rhi, clo, chi);
   for (int j=0; j<temp.cols(); j++)
     for (int i=0; i<temp.rows(); i++)
       temp(i, j) = pMat(i, j);

--- a/src/lmatrix.cc
+++ b/src/lmatrix.cc
@@ -384,17 +384,17 @@ IndexPartition LMatrix::UniformRowPartition
 (Context ctx, Runtime *runtime) {
 
   Rect<1> bounds(Point<1>(0),Point<1>(nPart-1));
-  Domain  domain(bounds);
+  IndexSpace color_space = runtime->create_index_space(ctx, bounds);
 
   int size = rblock;
-  DomainColoring coloring;
+  std::map<DomainPoint,Domain> coloring;
   for (int i = 0; i < nPart; i++) {
     Point<2> lo(  i   *size,   0);
     Point<2> hi( (i+1)*size-1, mCols-1);
     Rect<2> subrect(lo, hi);
     coloring[i] = Domain(subrect);
   }
-  return runtime->create_index_partition(ctx, ispace, domain, coloring, true);
+  return runtime->create_partition_by_domain(ctx, ispace, coloring, color_space);
 }
 
 IndexPartition LMatrix::UniformRowPartition
@@ -402,17 +402,17 @@ IndexPartition LMatrix::UniformRowPartition
  Context ctx, Runtime *runtime) {
 
   Rect<1> bounds(Point<1>(0),Point<1>(num_subregions-1));
-  Domain  domain(bounds);
+  IndexSpace color_space = runtime->create_index_space(ctx, bounds);
 
   int size = mRows / num_subregions;
-  DomainColoring coloring;
+  std::map<DomainPoint,Domain> coloring;
   for (int i = 0; i < num_subregions; i++) {
     Point<2> lo(  i   *size,   col0);
     Point<2> hi( (i+1)*size-1, col1-1);
     Rect<2> subrect(lo, hi);
     coloring[i] = Domain(subrect);
   }
-  return runtime->create_index_partition(ctx, ispace, domain, coloring, true);
+  return runtime->create_partition_by_domain(ctx, ispace, coloring, color_space);
 }
 
 Vector LMatrix::to_vector() {
@@ -501,9 +501,9 @@ void LMatrix::two_level_partition
     LogicalRegion lr = runtime->get_logical_subregion_by_color(ctx, lpart, i);
 
     Rect<1> bounds(Point<1>(0),Point<1>(1));
-    Domain  domain(bounds);
+    IndexSpace color_space = runtime->create_index_space(ctx, bounds);
     int size = rblock/2;
-    DomainColoring coloring;
+    std::map<DomainPoint,Domain> coloring;
     for (int j = 0; j < 2; j++) {
       Point<2> lo( i*rblock+j*size,   0);
       Point<2> hi( i*rblock+(j+1)*size-1, mCols-1);
@@ -511,7 +511,7 @@ void LMatrix::two_level_partition
       coloring[j] = Domain(subrect);
     }
     IndexSpace is = lr.get_index_space();
-    IndexPartition ip = runtime->create_index_partition(ctx, is, domain, coloring, true,0);
+    IndexPartition ip = runtime->create_partition_by_domain(ctx, is, coloring, color_space, true, LEGION_COMPUTE_KIND, 0);
     LogicalPartition lp = runtime->get_logical_partition(ctx, lr, ip);
     (void)lp;
   }

--- a/src/lmatrix.cc
+++ b/src/lmatrix.cc
@@ -103,7 +103,7 @@ void LMatrix::clear
   assert(nPart > 0);
   ClearMatrixTask::TaskArgs args = {rblock, mCols, value};
   ClearMatrixTask launcher(colDom, TaskArgument(&args, sizeof(args)), ArgumentMap());
-  RegionRequirement req(lpart, 0, WRITE_DISCARD, EXCLUSIVE, region);
+  RegionRequirement req(lpart, 0, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
   launcher.add_region_requirement(req);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
@@ -122,8 +122,8 @@ void LMatrix::scale
   ScaleMatrixTask::TaskArgs args = {this->rblock * plevel, mCols, alpha};
   TaskArgument tArg(&args, sizeof(args));
   ScaleMatrixTask launcher(colDom, tArg, ArgumentMap(), colDom.get_volume());
-  RegionRequirement req(lpart, 0, READ_WRITE, EXCLUSIVE, region);
-  //RegionRequirement req(lpart, 0, WRITE_DISCARD, EXCLUSIVE, region);
+  RegionRequirement req(lpart, 0, LEGION_READ_WRITE, LEGION_EXCLUSIVE, region);
+  //RegionRequirement req(lpart, 0, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
   launcher.add_region_requirement(req);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
@@ -155,8 +155,8 @@ void LMatrix::init_data
   InitMatrixTask::TaskArgs args = {rblock, mat.cols(), col0, col1};
   TaskArgument tArg(&args, sizeof(args));
   InitMatrixTask launcher(colDom, tArg, seeds, nPart);
-  //RegionRequirement req(lpart, 0, WRITE_DISCARD, EXCLUSIVE, region);
-  RegionRequirement req(lpart, 0, READ_WRITE, EXCLUSIVE, region);
+  //RegionRequirement req(lpart, 0, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, region);
+  RegionRequirement req(lpart, 0, LEGION_READ_WRITE, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
   launcher.add_region_requirement(req);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
@@ -177,7 +177,7 @@ void LMatrix::init_data
 
 Matrix LMatrix::to_matrix(Context ctx, Runtime *runtime) {
   Matrix temp(mRows, mCols);
-  RegionRequirement req(region, READ_ONLY, EXCLUSIVE, region);
+  RegionRequirement req(region, LEGION_READ_ONLY, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
  
   InlineLauncher launcher(req);
@@ -197,7 +197,7 @@ Matrix LMatrix::to_matrix
   assert(col0>=0);
   assert(col1<=mCols);
   Matrix temp(mRows, col1-col0);
-  RegionRequirement req(region, READ_ONLY, EXCLUSIVE, region);
+  RegionRequirement req(region, LEGION_READ_ONLY, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
  
   InlineLauncher launcher(req);
@@ -218,7 +218,7 @@ Matrix LMatrix::to_matrix
   assert(rlo>=0&&clo>=0);
   assert(rhi<=mRows&&chi<=mCols);
   Matrix temp(rhi-rlo, chi-clo);
-  RegionRequirement req(region, READ_ONLY, EXCLUSIVE, region);
+  RegionRequirement req(region, LEGION_READ_ONLY, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
  
   InlineLauncher launcher(req);
@@ -258,7 +258,7 @@ void LMatrix::init_data
   assert(false);
   InitMatrixTask::TaskArgs args;// = {mRows/nProc, mat.cols(), col0, col1};
   InitMatrixTask launcher(dom, TaskArgument(&args, sizeof(args)), seeds);
-  RegionRequirement req(lp, 0, WRITE_DISCARD, EXCLUSIVE, region);
+  RegionRequirement req(lp, 0, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
   launcher.add_region_requirement(req);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
@@ -284,7 +284,7 @@ void LMatrix::init_dense_blocks
   DenseBlockTask::TaskArgs args = {rblock, rank, D.offset()};
   TaskArgument tArg(&args, sizeof(args));
   DenseBlockTask launcher(colDom, tArg, seeds, this->nPart);
-  RegionRequirement req(lpart, 0, WRITE_DISCARD, EXCLUSIVE, region);
+  RegionRequirement req(lpart, 0, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
   launcher.add_region_requirement(req);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
@@ -312,7 +312,7 @@ void LMatrix::init_dense_blocks
   assert(false);
   DenseBlockTask::TaskArgs args;// = {mRows/nProc, mCols, U.cols(), nblk/nProc};
   DenseBlockTask launcher(dom, TaskArgument(&args, sizeof(args)), seeds);
-  RegionRequirement req(lp, 0, WRITE_DISCARD, EXCLUSIVE, region);
+  RegionRequirement req(lp, 0, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
   launcher.add_region_requirement(req);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
@@ -473,9 +473,9 @@ void LMatrix::solve
   LeafSolveTask::TaskArgs args = {this->rblock, b.cols(), V.cols(), V.small_block_parts()};
   TaskArgument tArg(&args, sizeof(args));
   LeafSolveTask launcher(domain, tArg, ArgumentMap(), nPart);
-  RegionRequirement AReq(APart, 0, READ_ONLY,  EXCLUSIVE, ARegion);
-  RegionRequirement bReq(bPart, 0, READ_WRITE, EXCLUSIVE, bRegion);
-  RegionRequirement VReq(VPart, 0, READ_ONLY,  EXCLUSIVE, VRegion);
+  RegionRequirement AReq(APart, 0, LEGION_READ_ONLY,  LEGION_EXCLUSIVE, ARegion);
+  RegionRequirement bReq(bPart, 0, LEGION_READ_WRITE, LEGION_EXCLUSIVE, bRegion);
+  RegionRequirement VReq(VPart, 0, LEGION_READ_ONLY,  LEGION_EXCLUSIVE, VRegion);
   AReq.add_field(FIELDID_V);
   bReq.add_field(FIELDID_V);
   VReq.add_field(FIELDID_V);
@@ -562,10 +562,10 @@ void LMatrix::node_solve
   NodeSolveTask::TaskArgs args = {rowBlk, mCols, b.cols()};
   NodeSolveTask launcher(domain, TaskArgument(&args, sizeof(args)),
 			 ArgumentMap(), domain.get_volume());
-  //RegionRequirement AReq(APart, 0, READ_ONLY,  EXCLUSIVE, ARegion);
+  //RegionRequirement AReq(APart, 0, LEGION_READ_ONLY,  LEGION_EXCLUSIVE, ARegion);
   // bug here: have to use stronger previlige
-  RegionRequirement AReq(APart, 0, READ_WRITE,  EXCLUSIVE, ARegion);
-  RegionRequirement bReq(bPart, 0, READ_WRITE, EXCLUSIVE, bRegion);
+  RegionRequirement AReq(APart, 0, LEGION_READ_WRITE,  LEGION_EXCLUSIVE, ARegion);
+  RegionRequirement bReq(bPart, 0, LEGION_READ_WRITE, LEGION_EXCLUSIVE, bRegion);
   AReq.add_field(FIELDID_V);
   bReq.add_field(FIELDID_V);
   launcher.add_region_requirement(AReq);
@@ -617,11 +617,11 @@ void LMatrix::node_solve
   int nRhs = VTd0.cols();
   NodeSolveRegionTask::TaskArgs args = {rank0, rank1, nRhs};
   NodeSolveRegionTask launcher(TaskArgument(&args, sizeof(args)));
-  //RegionRequirement AReq(ARegion, 0, READ_ONLY,  EXCLUSIVE, ARegion);
-  RegionRequirement VTu0_rq(VTu0_rg, READ_ONLY, EXCLUSIVE, VTu0_rg);
-  RegionRequirement VTu1_rq(VTu1_rg, READ_ONLY, EXCLUSIVE, VTu1_rg);
-  RegionRequirement VTd0_rq(VTd0_rg, READ_WRITE, EXCLUSIVE, VTd0_rg);
-  RegionRequirement VTd1_rq(VTd1_rg, READ_WRITE, EXCLUSIVE, VTd1_rg);
+  //RegionRequirement AReq(ARegion, 0, LEGION_READ_ONLY,  LEGION_EXCLUSIVE, ARegion);
+  RegionRequirement VTu0_rq(VTu0_rg, LEGION_READ_ONLY, LEGION_EXCLUSIVE, VTu0_rg);
+  RegionRequirement VTu1_rq(VTu1_rg, LEGION_READ_ONLY, LEGION_EXCLUSIVE, VTu1_rg);
+  RegionRequirement VTd0_rq(VTd0_rg, LEGION_READ_WRITE, LEGION_EXCLUSIVE, VTd0_rg);
+  RegionRequirement VTd1_rq(VTd1_rg, LEGION_READ_WRITE, LEGION_EXCLUSIVE, VTd1_rg);
   VTu0_rq.add_field(FIELDID_V);
   VTu1_rq.add_field(FIELDID_V);
   VTd0_rq.add_field(FIELDID_V);
@@ -651,8 +651,8 @@ void LMatrix::solve
 
   Domain domain = this->color_domain();
   SolveTask launcher(domain, TaskArgument(), ArgumentMap());
-  RegionRequirement AReq(APart, 0, READ_ONLY,  EXCLUSIVE, ARegion);
-  RegionRequirement bReq(bPart, 0, READ_WRITE, EXCLUSIVE, bRegion);
+  RegionRequirement AReq(APart, 0, LEGION_READ_ONLY,  LEGION_EXCLUSIVE, ARegion);
+  RegionRequirement bReq(bPart, 0, LEGION_READ_WRITE, LEGION_EXCLUSIVE, bRegion);
   AReq.add_field(FIELDID_V);
   bReq.add_field(FIELDID_V);
   launcher.add_region_requirement(AReq);
@@ -691,9 +691,9 @@ void LMatrix::add
   TaskArgument tArgs(&args, sizeof(args));
   Domain domain = A.color_domain();
   AddMatrixTask launcher(domain, tArgs, ArgumentMap());  
-  RegionRequirement AReq(APart, 0, READ_ONLY, EXCLUSIVE, AReg);
-  RegionRequirement BReq(BPart, 0, READ_ONLY, EXCLUSIVE, BReg);
-  RegionRequirement CReq(CPart, 0, WRITE_DISCARD, EXCLUSIVE, CReg);
+  RegionRequirement AReq(APart, 0, LEGION_READ_ONLY, LEGION_EXCLUSIVE, AReg);
+  RegionRequirement BReq(BPart, 0, LEGION_READ_ONLY, LEGION_EXCLUSIVE, BReg);
+  RegionRequirement CReq(CPart, 0, LEGION_WRITE_DISCARD, LEGION_EXCLUSIVE, CReg);
   AReq.add_field(FIELDID_V);
   BReq.add_field(FIELDID_V);
   CReq.add_field(FIELDID_V);
@@ -741,9 +741,9 @@ void LMatrix::gemmRed // static method
   Domain domain = A.color_domain();
   GemmRedTask launcher(domain, tArgs, ArgumentMap(), A.nPart);
   
-  RegionRequirement AReq(APart, 0,           READ_ONLY, EXCLUSIVE, AReg);
-  RegionRequirement BReq(BPart, 0,           READ_ONLY, EXCLUSIVE, BReg);
-  RegionRequirement CReq(CPart, CONTRACTION, REDOP_ADD, EXCLUSIVE, CReg);
+  RegionRequirement AReq(APart, 0,           LEGION_READ_ONLY, LEGION_EXCLUSIVE, AReg);
+  RegionRequirement BReq(BPart, 0,           LEGION_READ_ONLY, LEGION_EXCLUSIVE, BReg);
+  RegionRequirement CReq(CPart, CONTRACTION, REDOP_ADD, LEGION_EXCLUSIVE, CReg);
   AReq.add_field(FIELDID_V);
   BReq.add_field(FIELDID_V);
   CReq.add_field(FIELDID_V);
@@ -773,13 +773,13 @@ void LMatrix::gemm // static method
 			     A.cols(), B.cols(), C.cols()};
   GemmTask launcher(TaskArgument(&args, sizeof(args)));
   launcher.add_region_requirement
-    (RegionRequirement(A.logical_region(),READ_ONLY,EXCLUSIVE,A.logical_region())
+    (RegionRequirement(A.logical_region(),LEGION_READ_ONLY,LEGION_EXCLUSIVE,A.logical_region())
      .add_field(FIELDID_V));
   launcher.add_region_requirement
-    (RegionRequirement(B.logical_region(),READ_ONLY,EXCLUSIVE,B.logical_region())
+    (RegionRequirement(B.logical_region(),LEGION_READ_ONLY,LEGION_EXCLUSIVE,B.logical_region())
      .add_field(FIELDID_V));
   launcher.add_region_requirement
-    (RegionRequirement(C.logical_region(),READ_WRITE,EXCLUSIVE,C.logical_region())
+    (RegionRequirement(C.logical_region(),LEGION_READ_WRITE,LEGION_EXCLUSIVE,C.logical_region())
      .add_field(FIELDID_V));
   runtime->execute_task(ctx, launcher);
 }
@@ -797,13 +797,13 @@ void LMatrix::gemm_inplace // static method
 				    A.column_begin()};
   GemmInplaceTask launcher(TaskArgument(&args, sizeof(args)));
   launcher.add_region_requirement
-    (RegionRequirement(A.logical_region(),READ_WRITE,EXCLUSIVE,A.logical_region())
+    (RegionRequirement(A.logical_region(),LEGION_READ_WRITE,LEGION_EXCLUSIVE,A.logical_region())
      .add_field(FIELDID_V));
   launcher.add_region_requirement
-    (RegionRequirement(B.logical_region(),READ_ONLY,EXCLUSIVE,B.logical_region())
+    (RegionRequirement(B.logical_region(),LEGION_READ_ONLY,LEGION_EXCLUSIVE,B.logical_region())
      .add_field(FIELDID_V));
   //launcher.add_region_requirement
-  //  (RegionRequirement(C.logical_region(),READ_WRITE,EXCLUSIVE,C.logical_region())
+  //  (RegionRequirement(C.logical_region(),LEGION_READ_WRITE,LEGION_EXCLUSIVE,C.logical_region())
   //    .add_field(FIELDID_V));
   runtime->execute_task(ctx, launcher);
 }
@@ -843,11 +843,11 @@ void LMatrix::gemmBro // static method
   Domain domain = A.color_domain();
   GemmBroTask launcher(domain, tArgs, ArgumentMap(), A.nPart);
   
-  //RegionRequirement AReq(AP, 0,           READ_ONLY,  EXCLUSIVE, AReg);
-  RegionRequirement AReq(AP, 0,           READ_WRITE,  EXCLUSIVE, AReg);
-  RegionRequirement BReq(BP, CONTRACTION, READ_ONLY,  EXCLUSIVE, BReg);
-  //RegionRequirement BReq(BP, CONTRACTION, READ_WRITE,  EXCLUSIVE, BReg);
-  RegionRequirement CReq(CP, 0,           READ_WRITE, EXCLUSIVE, CReg);
+  //RegionRequirement AReq(AP, 0,           LEGION_READ_ONLY,  LEGION_EXCLUSIVE, AReg);
+  RegionRequirement AReq(AP, 0,           LEGION_READ_WRITE,  LEGION_EXCLUSIVE, AReg);
+  RegionRequirement BReq(BP, CONTRACTION, LEGION_READ_ONLY,  LEGION_EXCLUSIVE, BReg);
+  //RegionRequirement BReq(BP, CONTRACTION, LEGION_READ_WRITE,  LEGION_EXCLUSIVE, BReg);
+  RegionRequirement CReq(CP, 0,           LEGION_READ_WRITE, LEGION_EXCLUSIVE, CReg);
   AReq.add_field(FIELDID_V);
   BReq.add_field(FIELDID_V);
   CReq.add_field(FIELDID_V);
@@ -868,11 +868,11 @@ void LMatrix::display
 (const std::string& name,
  Context ctx, Runtime *runtime, bool wait) {
 
-  Domain dom = runtime->get_index_space_domain(ctx, region.get_index_space());
-  assert(colIdx+mCols<=dom.get_rect<2>().dim_size(1));
+  const Rect<2> rect = runtime->get_index_space_domain(ctx, region.get_index_space());
+  assert(colIdx+mCols<=(rect.hi[1] - rect.lo[1] + 1));
   DisplayMatrixTask::TaskArgs args(name, mRows, mCols, colIdx);
   DisplayMatrixTask launcher(TaskArgument(&args, sizeof(args)));
-  RegionRequirement req(region, READ_ONLY, EXCLUSIVE, region);
+  RegionRequirement req(region, LEGION_READ_ONLY, LEGION_EXCLUSIVE, region);
   req.add_field(FIELDID_V);
   launcher.add_region_requirement(req);
   Future f = runtime->execute_task(ctx, launcher);

--- a/src/tasks/add_matrix.cc
+++ b/src/tasks/add_matrix.cc
@@ -48,8 +48,8 @@ void AddMatrixTask::cpu_task(const Task *task,
   int rlo = p[0]*rblk;
   int rhi = (p[0] + 1) * rblk;
   
-  PtrMatrix AMat = get_raw_pointer(regions[0], rlo, rhi, 0, cols);
-  PtrMatrix BMat = get_raw_pointer(regions[1], rlo, rhi, 0, cols);
-  PtrMatrix CMat = get_raw_pointer(regions[2], rlo, rhi, 0, cols);
+  PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], rlo, rhi, 0, cols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], rlo, rhi, 0, cols);
+  PtrMatrix CMat = get_raw_pointer<LEGION_READ_WRITE>(regions[2], rlo, rhi, 0, cols);
   PtrMatrix::add(alpha, AMat, beta, BMat, CMat);
 }

--- a/src/tasks/add_matrix.cc
+++ b/src/tasks/add_matrix.cc
@@ -17,7 +17,7 @@ AddMatrixTask::AddMatrixTask(Domain domain,
 
 void AddMatrixTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <AddMatrixTask::cpu_task>(AUTO_GENERATE_ID,
 			    Processor::LOC_PROC, 
 			    false,
@@ -33,13 +33,13 @@ void AddMatrixTask::register_tasks(void)
 
 void AddMatrixTask::cpu_task(const Task *task,
 			     const std::vector<PhysicalRegion> &regions,
-			     Context ctx, HighLevelRuntime *runtime) {
+			     Context ctx, Runtime *runtime) {
 
   assert(regions.size() == 3);
   assert(task->regions.size() == 3);
   assert(task->arglen == sizeof(TaskArgs));
 
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point);
   //printf("point = %d\n", p[0]);
 
   const TaskArgs args = *((const TaskArgs*)task->args);

--- a/src/tasks/add_matrix.cc
+++ b/src/tasks/add_matrix.cc
@@ -17,14 +17,11 @@ AddMatrixTask::AddMatrixTask(Domain domain,
 
 void AddMatrixTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <AddMatrixTask::cpu_task>(AUTO_GENERATE_ID,
-			    Processor::LOC_PROC, 
-			    false,
-			    true,
-			    AUTO_GENERATE_ID,
-			    TaskConfigOptions(true/*leaf*/),
-			    "add_matrix");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Add_Matrix");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<AddMatrixTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : add_matrix\n", TASKID);

--- a/src/tasks/clear_matrix.cc
+++ b/src/tasks/clear_matrix.cc
@@ -17,7 +17,7 @@ ClearMatrixTask::ClearMatrixTask(Domain domain,
 
 void ClearMatrixTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <ClearMatrixTask::cpu_task>(AUTO_GENERATE_ID,
 			       Processor::LOC_PROC, 
 			       false,
@@ -33,12 +33,12 @@ void ClearMatrixTask::register_tasks(void)
 
 void ClearMatrixTask::cpu_task(const Task *task,
 			      const std::vector<PhysicalRegion> &regions,
-			      Context ctx, HighLevelRuntime *runtime) {
+			      Context ctx, Runtime *runtime) {
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);
   assert(task->arglen == sizeof(TaskArgs));
 
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point.get_point<1>());
   //printf("point = %d\n", p[0]);
 
   const TaskArgs args = *((const TaskArgs*)task->args);

--- a/src/tasks/clear_matrix.cc
+++ b/src/tasks/clear_matrix.cc
@@ -46,6 +46,6 @@ void ClearMatrixTask::cpu_task(const Task *task,
   int rlo = p[0]*rblk;
   int rhi = (p[0] + 1) * rblk;
   //double *base = region_pointer(regions[0], rlo, rhi, 0, cols);
-  PtrMatrix A = get_raw_pointer(regions[0], rlo, rhi, 0, cols);
+  PtrMatrix A = get_raw_pointer<LEGION_READ_WRITE>(regions[0], rlo, rhi, 0, cols);
   A.clear(value);
 }

--- a/src/tasks/clear_matrix.cc
+++ b/src/tasks/clear_matrix.cc
@@ -35,7 +35,7 @@ void ClearMatrixTask::cpu_task(const Task *task,
   assert(task->regions.size() == 1);
   assert(task->arglen == sizeof(TaskArgs));
 
-  Point<1> p(task->index_point.get_point<1>());
+  Point<1> p = task->index_point;
   //printf("point = %d\n", p[0]);
 
   const TaskArgs args = *((const TaskArgs*)task->args);

--- a/src/tasks/clear_matrix.cc
+++ b/src/tasks/clear_matrix.cc
@@ -17,14 +17,11 @@ ClearMatrixTask::ClearMatrixTask(Domain domain,
 
 void ClearMatrixTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <ClearMatrixTask::cpu_task>(AUTO_GENERATE_ID,
-			       Processor::LOC_PROC, 
-			       false,
-			       true,
-			       AUTO_GENERATE_ID,
-			       TaskConfigOptions(true/*leaf*/),
-			       "Clear_Matrix");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Clear_Matrix");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<ClearMatrixTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Clear_Matrix\n", TASKID);

--- a/src/tasks/dense_block.cc
+++ b/src/tasks/dense_block.cc
@@ -61,7 +61,7 @@ void DenseBlockTask::cpu_task(const Task *task,
   const long nPart = *((const long*)task->local_args);
   int rblk = nrow / nPart;
   for (int i=0; i<nPart; i++) {
-    PtrMatrix K = get_raw_pointer(regions[0], rlo+i*rblk, rlo+(i+1)*rblk, 0, rblk);
+    PtrMatrix K = get_raw_pointer<LEGION_READ_WRITE>(regions[0], rlo+i*rblk, rlo+(i+1)*rblk, 0, rblk);
     // recover U, V and D
     PtrMatrix U(rblk, rank), V(rblk, rank), D(rblk, 1);
     const long uSeed = *((const long*)task->local_args + 1 + 3*i + 0);

--- a/src/tasks/dense_block.cc
+++ b/src/tasks/dense_block.cc
@@ -21,7 +21,7 @@ DenseBlockTask::DenseBlockTask(Domain domain,
 
 void DenseBlockTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <DenseBlockTask::cpu_task>(AUTO_GENERATE_ID,
 			       Processor::LOC_PROC, 
 			       false,
@@ -37,7 +37,7 @@ void DenseBlockTask::register_tasks(void)
 
 void DenseBlockTask::cpu_task(const Task *task,
 			      const std::vector<PhysicalRegion> &regions,
-			      Context ctx, HighLevelRuntime *runtime) {
+			      Context ctx, Runtime *runtime) {
 
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);
@@ -45,7 +45,7 @@ void DenseBlockTask::cpu_task(const Task *task,
   //  assert(task->local_arglen == sizeof(ThreeSeeds));
   log_solver_tasks.print("Inside init dense block tasks.");
   
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point);
   //printf("point = %d\n", p[0]);
 
   //const ThreeSeeds seeds = *((const ThreeSeeds*)task->local_args);

--- a/src/tasks/dense_block.cc
+++ b/src/tasks/dense_block.cc
@@ -21,14 +21,11 @@ DenseBlockTask::DenseBlockTask(Domain domain,
 
 void DenseBlockTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <DenseBlockTask::cpu_task>(AUTO_GENERATE_ID,
-			       Processor::LOC_PROC, 
-			       false,
-			       true,
-			       AUTO_GENERATE_ID,
-			       TaskConfigOptions(true/*leaf*/),
-			       "Dense_Block");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Dense_Block");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<DenseBlockTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Dense_Block\n", TASKID);

--- a/src/tasks/display_matrix.cc
+++ b/src/tasks/display_matrix.cc
@@ -45,7 +45,7 @@ void DisplayMatrixTask::cpu_task
   const int   cols = args.cols;
   const int   colIdx = args.colIdx;
   
-  PtrMatrix A = get_raw_pointer(regions[0], 0, rows, colIdx, colIdx+cols);
+  PtrMatrix A = get_raw_pointer<LEGION_READ_WRITE>(regions[0], 0, rows, colIdx, colIdx+cols);
   A.display(name);
 }
 

--- a/src/tasks/display_matrix.cc
+++ b/src/tasks/display_matrix.cc
@@ -20,14 +20,11 @@ DisplayMatrixTask::DisplayMatrixTask
 
 void DisplayMatrixTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <DisplayMatrixTask::cpu_task>(AUTO_GENERATE_ID,
-				  Processor::LOC_PROC, 
-				  true,
-				  false,
-				  AUTO_GENERATE_ID,
-				  TaskConfigOptions(true/*leaf*/),
-				  "Display_Matrix");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Display_Matrix");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<DisplayMatrixTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Display_Matrix\n", TASKID);

--- a/src/tasks/display_matrix.cc
+++ b/src/tasks/display_matrix.cc
@@ -20,7 +20,7 @@ DisplayMatrixTask::DisplayMatrixTask
 
 void DisplayMatrixTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <DisplayMatrixTask::cpu_task>(AUTO_GENERATE_ID,
 				  Processor::LOC_PROC, 
 				  true,
@@ -36,7 +36,7 @@ void DisplayMatrixTask::register_tasks(void)
 
 void DisplayMatrixTask::cpu_task
 (const Task *task, const std::vector<PhysicalRegion> &regions,
- Context ctx, HighLevelRuntime *runtime) {
+ Context ctx, Runtime *runtime) {
   
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);

--- a/src/tasks/dist_mapper.cc
+++ b/src/tasks/dist_mapper.cc
@@ -1,7 +1,7 @@
 #include "dist_mapper.hpp"
 
 DistMapper::DistMapper
-(Machine m, HighLevelRuntime *rt, Processor p, int radix_)
+(Machine m, Runtime *rt, Processor p, int radix_)
   : DefaultMapper(m, rt, p) {
 
   this->radix = radix_;

--- a/src/tasks/gemm.cc
+++ b/src/tasks/gemm.cc
@@ -14,14 +14,11 @@ GemmTask::GemmTask(TaskArgument arg,
 
 void GemmTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <GemmTask::cpu_task>(AUTO_GENERATE_ID,
-			 Processor::LOC_PROC, 
-			 true,
-			 false,
-			 AUTO_GENERATE_ID,
-			 TaskConfigOptions(true/*leaf*/),
-			 "Gemm");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Gemm");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<GemmTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Gemm\n", TASKID);

--- a/src/tasks/gemm.cc
+++ b/src/tasks/gemm.cc
@@ -55,9 +55,9 @@ void GemmTask::cpu_task(const Task *task,
 	 Brows, BcolIdx, Bcols,
 	 Crows, Ccols);
 #endif
-  PtrMatrix AMat = get_raw_pointer(regions[0], 0, Arows, AcolIdx, AcolIdx+Acols);
-  PtrMatrix BMat = get_raw_pointer(regions[1], 0, Brows, BcolIdx, BcolIdx+Bcols);
-  PtrMatrix CMat = get_raw_pointer(regions[2], 0, Crows, 0,       Ccols);
+  PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], 0, Arows, AcolIdx, AcolIdx+Acols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], 0, Brows, BcolIdx, BcolIdx+Bcols);
+  PtrMatrix CMat = get_raw_pointer<LEGION_READ_WRITE>(regions[2], 0, Crows, 0,       Ccols);
   AMat.set_trans(transA);
   BMat.set_trans(transB);
 

--- a/src/tasks/gemm.cc
+++ b/src/tasks/gemm.cc
@@ -14,7 +14,7 @@ GemmTask::GemmTask(TaskArgument arg,
 
 void GemmTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <GemmTask::cpu_task>(AUTO_GENERATE_ID,
 			 Processor::LOC_PROC, 
 			 true,
@@ -30,7 +30,7 @@ void GemmTask::register_tasks(void)
 
 void GemmTask::cpu_task(const Task *task,
 			   const std::vector<PhysicalRegion> &regions,
-			   Context ctx, HighLevelRuntime *runtime) {
+			   Context ctx, Runtime *runtime) {
   assert(regions.size() == 3);
   assert(task->regions.size() == 3);
   assert(task->arglen == sizeof(TaskArgs));

--- a/src/tasks/gemm_broadcast.cc
+++ b/src/tasks/gemm_broadcast.cc
@@ -19,14 +19,11 @@ GemmBroTask::GemmBroTask(Domain domain,
 
 void GemmBroTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <GemmBroTask::cpu_task>(AUTO_GENERATE_ID,
-			    Processor::LOC_PROC, 
-			    false,
-			    true,
-			    AUTO_GENERATE_ID,
-			    TaskConfigOptions(true/*leaf*/),
-			    "GemmBroadcast");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Gemm_Bro");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<GemmBroTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : GemmBroadcast\n", TASKID);

--- a/src/tasks/gemm_broadcast.cc
+++ b/src/tasks/gemm_broadcast.cc
@@ -19,7 +19,7 @@ GemmBroTask::GemmBroTask(Domain domain,
 
 void GemmBroTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <GemmBroTask::cpu_task>(AUTO_GENERATE_ID,
 			    Processor::LOC_PROC, 
 			    false,
@@ -35,14 +35,14 @@ void GemmBroTask::register_tasks(void)
 
 void GemmBroTask::cpu_task(const Task *task,
 			   const std::vector<PhysicalRegion> &regions,
-			   Context ctx, HighLevelRuntime *runtime) {
+			   Context ctx, Runtime *runtime) {
 
   //assert(regions.size() == 3);
   //assert(task->regions.size() == 3);
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   assert(task->arglen == sizeof(TaskArgs));
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point);
   //printf("point = %d\n", p[0]);
 
   log_solver_tasks.print("Inside gemm broadcast tasks.");

--- a/src/tasks/gemm_broadcast.cc
+++ b/src/tasks/gemm_broadcast.cc
@@ -66,7 +66,7 @@ void GemmBroTask::cpu_task(const Task *task,
   int Brhi = (color + 1) * Brblk;
   
   PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], Arlo, Arhi, AcolIdx, AcolIdx+Acols);
-  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], Brlo, Brhi, 0, Bcols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_ONLY>(regions[1], Brlo, Brhi, 0, Bcols);
   //PtrMatrix CMat = get_raw_pointer<LEGION_READ_WRITE>(regions[2], Crlo, Crhi, 0, Ccols);
   PtrMatrix CMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], Crlo, Crhi, 0, Ccols);
   AMat.set_trans(args.transa);

--- a/src/tasks/gemm_broadcast.cc
+++ b/src/tasks/gemm_broadcast.cc
@@ -65,10 +65,10 @@ void GemmBroTask::cpu_task(const Task *task,
   int Brlo = color*Brblk;
   int Brhi = (color + 1) * Brblk;
   
-  PtrMatrix AMat = get_raw_pointer(regions[0], Arlo, Arhi, AcolIdx, AcolIdx+Acols);
-  PtrMatrix BMat = get_raw_pointer(regions[1], Brlo, Brhi, 0, Bcols);
-  //PtrMatrix CMat = get_raw_pointer(regions[2], Crlo, Crhi, 0, Ccols);
-  PtrMatrix CMat = get_raw_pointer(regions[0], Crlo, Crhi, 0, Ccols);
+  PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], Arlo, Arhi, AcolIdx, AcolIdx+Acols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], Brlo, Brhi, 0, Bcols);
+  //PtrMatrix CMat = get_raw_pointer<LEGION_READ_WRITE>(regions[2], Crlo, Crhi, 0, Ccols);
+  PtrMatrix CMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], Crlo, Crhi, 0, Ccols);
   AMat.set_trans(args.transa);
   BMat.set_trans(args.transb);
   double alpha = args.alpha;

--- a/src/tasks/gemm_inplace.cc
+++ b/src/tasks/gemm_inplace.cc
@@ -12,14 +12,11 @@ GemmInplaceTask::GemmInplaceTask
 
 void GemmInplaceTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <GemmInplaceTask::cpu_task>(AUTO_GENERATE_ID,
-			 Processor::LOC_PROC, 
-			 true,
-			 false,
-			 AUTO_GENERATE_ID,
-			 TaskConfigOptions(true/*leaf*/),
-			 "GemmInplace");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Gemm_Inplace");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<GemmInplaceTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : GemmInplace\n", TASKID);

--- a/src/tasks/gemm_inplace.cc
+++ b/src/tasks/gemm_inplace.cc
@@ -12,7 +12,7 @@ GemmInplaceTask::GemmInplaceTask
 
 void GemmInplaceTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <GemmInplaceTask::cpu_task>(AUTO_GENERATE_ID,
 			 Processor::LOC_PROC, 
 			 true,
@@ -28,7 +28,7 @@ void GemmInplaceTask::register_tasks(void)
 
 void GemmInplaceTask::cpu_task(const Task *task,
 			   const std::vector<PhysicalRegion> &regions,
-			   Context ctx, HighLevelRuntime *runtime) {
+			   Context ctx, Runtime *runtime) {
   
   //printf("Inside gemm inplace tasks.\n");
 

--- a/src/tasks/gemm_inplace.cc
+++ b/src/tasks/gemm_inplace.cc
@@ -53,9 +53,9 @@ void GemmInplaceTask::cpu_task(const Task *task,
 	 Brows, Bcols,
 	 Crows, Ccols);
 #endif
-  PtrMatrix AMat = get_raw_pointer(regions[0], 0, Arows, AcolIdx, AcolIdx+Acols);
-  PtrMatrix BMat = get_raw_pointer(regions[1], 0, Brows, 0, Bcols);
-  PtrMatrix CMat = get_raw_pointer(regions[0], 0, Crows, 0, Ccols);
+  PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], 0, Arows, AcolIdx, AcolIdx+Acols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], 0, Brows, 0, Bcols);
+  PtrMatrix CMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], 0, Crows, 0, Ccols);
   AMat.set_trans(transA);
   BMat.set_trans(transB);
 

--- a/src/tasks/gemm_reduce.cc
+++ b/src/tasks/gemm_reduce.cc
@@ -65,8 +65,8 @@ void GemmRedTask::cpu_task(const Task *task,
   int Crlo = color*Crblk;
   int Crhi = (color + 1) * Crblk;
   
-  PtrMatrix AMat = get_raw_pointer(regions[0], Arlo, Arhi, AcolIdx, AcolIdx+Acols);
-  PtrMatrix BMat = get_raw_pointer(regions[1], Brlo, Brhi, BcolIdx, BcolIdx+Bcols);
+  PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], Arlo, Arhi, AcolIdx, AcolIdx+Acols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], Brlo, Brhi, BcolIdx, BcolIdx+Bcols);
   PtrMatrix CMat = reduction_pointer(regions[2], Crlo, Crhi, CcolIdx, CcolIdx+Ccols);
   AMat.set_trans(args.transa);
   BMat.set_trans(args.transb);

--- a/src/tasks/gemm_reduce.cc
+++ b/src/tasks/gemm_reduce.cc
@@ -19,14 +19,11 @@ GemmRedTask::GemmRedTask(Domain domain,
 
 void GemmRedTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <GemmRedTask::cpu_task>(AUTO_GENERATE_ID,
-			    Processor::LOC_PROC, 
-			    false,
-			    true,
-			    AUTO_GENERATE_ID,
-			    TaskConfigOptions(true/*leaf*/),
-			    "GemmRed");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Gemm_Red");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<GemmRedTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : GemmRed\n", TASKID);

--- a/src/tasks/gemm_reduce.cc
+++ b/src/tasks/gemm_reduce.cc
@@ -65,8 +65,8 @@ void GemmRedTask::cpu_task(const Task *task,
   int Crlo = color*Crblk;
   int Crhi = (color + 1) * Crblk;
   
-  PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], Arlo, Arhi, AcolIdx, AcolIdx+Acols);
-  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], Brlo, Brhi, BcolIdx, BcolIdx+Bcols);
+  PtrMatrix AMat = get_raw_pointer<LEGION_READ_ONLY>(regions[0], Arlo, Arhi, AcolIdx, AcolIdx+Acols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_ONLY>(regions[1], Brlo, Brhi, BcolIdx, BcolIdx+Bcols);
   PtrMatrix CMat = reduction_pointer(regions[2], Crlo, Crhi, CcolIdx, CcolIdx+Ccols);
   AMat.set_trans(args.transa);
   BMat.set_trans(args.transb);

--- a/src/tasks/gemm_reduce.cc
+++ b/src/tasks/gemm_reduce.cc
@@ -19,7 +19,7 @@ GemmRedTask::GemmRedTask(Domain domain,
 
 void GemmRedTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <GemmRedTask::cpu_task>(AUTO_GENERATE_ID,
 			    Processor::LOC_PROC, 
 			    false,
@@ -35,12 +35,12 @@ void GemmRedTask::register_tasks(void)
 
 void GemmRedTask::cpu_task(const Task *task,
 			   const std::vector<PhysicalRegion> &regions,
-			   Context ctx, HighLevelRuntime *runtime) {
+			   Context ctx, Runtime *runtime) {
 
   assert(regions.size() == 3);
   assert(task->regions.size() == 3);
   assert(task->arglen == sizeof(TaskArgs));
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point);
   //printf("point = %d\n", p[0]);
 
   log_solver_tasks.print("Inside gemm reduction tasks.");

--- a/src/tasks/init_matrix.cc
+++ b/src/tasks/init_matrix.cc
@@ -21,7 +21,7 @@ InitMatrixTask::InitMatrixTask(Domain domain,
 
 void InitMatrixTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <InitMatrixTask::cpu_task>(AUTO_GENERATE_ID,
 			       Processor::LOC_PROC, 
 			       false,
@@ -37,14 +37,14 @@ void InitMatrixTask::register_tasks(void)
 
 void InitMatrixTask::cpu_task(const Task *task,
 			      const std::vector<PhysicalRegion> &regions,
-			      Context ctx, HighLevelRuntime *runtime) {
+			      Context ctx, Runtime *runtime) {
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);
   assert(task->arglen == sizeof(TaskArgs));
   //assert(task->local_arglen == sizeof(long));
   log_solver_tasks.print("Inside init tasks.");
 
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point);
   //printf("point = %d\n", p[0]);
 
   const long nPart = *((const long*)task->local_args);

--- a/src/tasks/init_matrix.cc
+++ b/src/tasks/init_matrix.cc
@@ -21,14 +21,11 @@ InitMatrixTask::InitMatrixTask(Domain domain,
 
 void InitMatrixTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <InitMatrixTask::cpu_task>(AUTO_GENERATE_ID,
-			       Processor::LOC_PROC, 
-			       false,
-			       true,
-			       AUTO_GENERATE_ID,
-			       TaskConfigOptions(true/*leaf*/),
-			       "Init_Matrix");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Init_Matrix");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<InitMatrixTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Init_Matrix\n", TASKID);

--- a/src/tasks/init_matrix.cc
+++ b/src/tasks/init_matrix.cc
@@ -63,7 +63,7 @@ void InitMatrixTask::cpu_task(const Task *task,
     //printf(" seed = %lu \n", seed);
     int clo   = blockSize.clo;
     while (clo+cblk <= chi) {
-      PtrMatrix A = get_raw_pointer(regions[0], rlo+i*blksmall, rlo+(i+1)*blksmall, clo, clo+cblk);
+      PtrMatrix A = get_raw_pointer<LEGION_READ_WRITE>(regions[0], rlo+i*blksmall, rlo+(i+1)*blksmall, clo, clo+cblk);
       A.rand(seed);
       //A.display("sub-mat");
       //std::cout<<"LD:"<<A.LD()<<std::endl;

--- a/src/tasks/leaf_solve.cc
+++ b/src/tasks/leaf_solve.cc
@@ -54,9 +54,9 @@ void LeafSolveTask::cpu_task(const Task *task,
   //assert(rank*nPart==rblk);
   int rlo = p[0]*rblk;
   int rhi = (p[0] + 1) * rblk;
-  PtrMatrix KMat = get_raw_pointer(regions[0], rlo, rhi, 0, rblk/nPart);
-  PtrMatrix UMat = get_raw_pointer(regions[1], rlo, rhi, 0, nRhs);
-  PtrMatrix VMat = get_raw_pointer(regions[2], rlo, rhi, 0, rank);
+  PtrMatrix KMat = get_raw_pointer<LEGION_READ_ONLY>(regions[0], rlo, rhi, 0, rblk/nPart);
+  PtrMatrix UMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], rlo, rhi, 0, nRhs);
+  PtrMatrix VMat = get_raw_pointer<LEGION_READ_ONLY>(regions[2], rlo, rhi, 0, rank);
   assert(KMat.LD() == UMat.LD());
   assert(KMat.LD() == VMat.LD());
   //std::cout<<"nPart:"<<nPart<<", level:"<<level<<std::endl;

--- a/src/tasks/leaf_solve.cc
+++ b/src/tasks/leaf_solve.cc
@@ -24,14 +24,11 @@ LeafSolveTask::LeafSolveTask(Domain domain,
 
 void LeafSolveTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <LeafSolveTask::cpu_task>(AUTO_GENERATE_ID,
-			    Processor::LOC_PROC, 
-			    false,
-			    true,
-			    AUTO_GENERATE_ID,
-			    TaskConfigOptions(true/*leaf*/),
-			    "Leaf_Solve");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Leaf_Solve");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<LeafSolveTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Leaf_Solve\n", TASKID);

--- a/src/tasks/leaf_solve.cc
+++ b/src/tasks/leaf_solve.cc
@@ -24,7 +24,7 @@ LeafSolveTask::LeafSolveTask(Domain domain,
 
 void LeafSolveTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <LeafSolveTask::cpu_task>(AUTO_GENERATE_ID,
 			    Processor::LOC_PROC, 
 			    false,
@@ -40,12 +40,12 @@ void LeafSolveTask::register_tasks(void)
 
 void LeafSolveTask::cpu_task(const Task *task,
 			     const std::vector<PhysicalRegion> &regions,
-			     Context ctx, HighLevelRuntime *runtime) {
+			     Context ctx, Runtime *runtime) {
 
   assert(regions.size() == 3);
   assert(task->regions.size() == 3);
   assert(task->arglen == sizeof(TaskArgs));
-  Point<1> p = task->index_point.get_point<1>();  
+  Point<1> p(task->index_point);  
   log_solver_tasks.print("Inside leaf solve tasks.");
 
   const TaskArgs args = *((const TaskArgs*)task->args);

--- a/src/tasks/mapper.cc
+++ b/src/tasks/mapper.cc
@@ -5,7 +5,7 @@
 Realm::Logger log_solver_mapper("solver_mapper");
 
 SolverMapper::SolverMapper
-(Machine m, HighLevelRuntime *rt, Processor p)
+(Machine m, Runtime *rt, Processor p)
   : DefaultMapper(m, rt, p) {
 
   // select and store all SYSTEM_MEM's in valid_mems

--- a/src/tasks/new_mapper.cc
+++ b/src/tasks/new_mapper.cc
@@ -2,7 +2,7 @@
 
 #include "new_mapper.hpp"
 
-using namespace LegionRuntime;
+using namespace Legion;
 
 Realm::Logger log_solver_mapper("solver_mapper");
 
@@ -47,8 +47,8 @@ void SolverMapper::default_slice_task(const Task &task,
   }
 
   assert(input.domain.get_dim() == 1);
-  Arrays::Rect<1> point_rect = input.domain.get_rect<1>();
-  Arrays::Point<1> num_blocks(local.size());
+  Rect<1> point_rect(input.domain);
+  Point<1> num_blocks(local.size());
   default_decompose_points<1>(point_rect, local,
 			      num_blocks, false/*recurse*/,
 			      stealing_enabled, output.slices);  

--- a/src/tasks/node_solve.cc
+++ b/src/tasks/node_solve.cc
@@ -54,8 +54,8 @@ void NodeSolveTask::cpu_task(const Task *task,
   int rhi = (p[0] + 1) * rblk;
   //printf("(rblock=%d, Acols=%d, Bcols=%d)\n", rblk, Acols, Bcols);
   
-  PtrMatrix AMat = get_raw_pointer(regions[0], rlo, rhi, 0, Acols);
-  PtrMatrix BMat = get_raw_pointer(regions[1], rlo, rhi, 0, Bcols);
+  PtrMatrix AMat = get_raw_pointer<LEGION_READ_WRITE>(regions[0], rlo, rhi, 0, Acols);
+  PtrMatrix BMat = get_raw_pointer<LEGION_READ_WRITE>(regions[1], rlo, rhi, 0, Bcols);
 
   PtrMatrix S(rblk, rblk);
   S.identity(); // initialize to identity matrix

--- a/src/tasks/node_solve.cc
+++ b/src/tasks/node_solve.cc
@@ -16,7 +16,7 @@ NodeSolveTask::NodeSolveTask(Domain domain,
 
 void NodeSolveTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <NodeSolveTask::cpu_task>(AUTO_GENERATE_ID,
 			      Processor::LOC_PROC, 
 			      false,
@@ -39,12 +39,12 @@ void NodeSolveTask::register_tasks(void)
 // note the reversed order in VTd
 void NodeSolveTask::cpu_task(const Task *task,
 			     const std::vector<PhysicalRegion> &regions,
-			     Context ctx, HighLevelRuntime *runtime) {
+			     Context ctx, Runtime *runtime) {
 
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   assert(task->arglen == sizeof(TaskArgs));
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point);
   //  printf("point = %d\n", p[0]);
 
   log_solver_tasks.print("Inside node solve tasks.");

--- a/src/tasks/node_solve.cc
+++ b/src/tasks/node_solve.cc
@@ -16,14 +16,11 @@ NodeSolveTask::NodeSolveTask(Domain domain,
 
 void NodeSolveTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <NodeSolveTask::cpu_task>(AUTO_GENERATE_ID,
-			      Processor::LOC_PROC, 
-			      false,
-			      true,
-			      AUTO_GENERATE_ID,
-			      TaskConfigOptions(true/*leaf*/),
-			      "Node_Solve");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Node_Solve");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<NodeSolveTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Node_Solve\n", TASKID);

--- a/src/tasks/node_solve_region.cc
+++ b/src/tasks/node_solve_region.cc
@@ -69,10 +69,10 @@ void NodeSolveRegionTask::cpu_task(const Task *task,
   int nRhs  = args.nRhs;
   //printf("rank=%d, nRhs=%d\n", rank, nRhs);
 
-  PtrMatrix VTu0 = get_raw_pointer(regions[0], 0, rank1, 0, rank0);
-  PtrMatrix VTu1 = get_raw_pointer(regions[1], 0, rank0, 0, rank1);
-  PtrMatrix VTd0 = get_raw_pointer(regions[2], 0, rank1, 0, nRhs);
-  PtrMatrix VTd1 = get_raw_pointer(regions[3], 0, rank0, 0, nRhs);
+  PtrMatrix VTu0 = get_raw_pointer<LEGION_READ_WRITE>(regions[0], 0, rank1, 0, rank0);
+  PtrMatrix VTu1 = get_raw_pointer<LEGION_READ_WRITE>(regions[1], 0, rank0, 0, rank1);
+  PtrMatrix VTd0 = get_raw_pointer<LEGION_READ_WRITE>(regions[2], 0, rank1, 0, nRhs);
+  PtrMatrix VTd1 = get_raw_pointer<LEGION_READ_WRITE>(regions[3], 0, rank0, 0, nRhs);
  
   int N = rank0 + rank1;
   PtrMatrix S(N, N);

--- a/src/tasks/node_solve_region.cc
+++ b/src/tasks/node_solve_region.cc
@@ -14,14 +14,11 @@ NodeSolveRegionTask::NodeSolveRegionTask(TaskArgument arg,
 
 void NodeSolveRegionTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <NodeSolveRegionTask::cpu_task>(AUTO_GENERATE_ID,
-				    Processor::LOC_PROC, 
-				    true,
-				    false,
-				    AUTO_GENERATE_ID,
-				    TaskConfigOptions(true/*leaf*/),
-				    "Node_Solve_Region");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Node_Solve_Region");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<NodeSolveRegionTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Node_Solve_Region\n", TASKID);

--- a/src/tasks/node_solve_region.cc
+++ b/src/tasks/node_solve_region.cc
@@ -14,7 +14,7 @@ NodeSolveRegionTask::NodeSolveRegionTask(TaskArgument arg,
 
 void NodeSolveRegionTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <NodeSolveRegionTask::cpu_task>(AUTO_GENERATE_ID,
 				    Processor::LOC_PROC, 
 				    true,
@@ -37,7 +37,7 @@ void NodeSolveRegionTask::register_tasks(void)
 // note the reverse order in VTd
 void NodeSolveRegionTask::cpu_task(const Task *task,
 			     const std::vector<PhysicalRegion> &regions,
-			     Context ctx, HighLevelRuntime *runtime) {
+			     Context ctx, Runtime *runtime) {
 
   //printf("Inside node solve tasks.\n");
 #if 0

--- a/src/tasks/projector.cc
+++ b/src/tasks/projector.cc
@@ -2,7 +2,7 @@
 
 const ProjectionID CONTRACTION = 1988;
 
-Contraction::Contraction(HighLevelRuntime *runtime)
+Contraction::Contraction(Runtime *runtime)
   : ProjectionFunctor(runtime) {
   //std::cout<<"Register projection functor with ID: "<<CONTRACTION<<std::endl;
 }

--- a/src/tasks/random_mapper.cc
+++ b/src/tasks/random_mapper.cc
@@ -5,7 +5,7 @@
 #include <random>       // std::default_random_engine
 #include <chrono>       // std::chrono::system_clock
 
-using namespace LegionRuntime;
+using namespace Legion;
 
 //Realm::Logger log_solver_mapper("random_mapper");
 
@@ -58,8 +58,8 @@ void RandomMapper::default_slice_task(const Task &task,
   shuffle(procs.begin(), procs.end(), std::default_random_engine(seed));
 
   assert(input.domain.get_dim() == 1);
-  Arrays::Rect<1> point_rect = input.domain.get_rect<1>();
-  Arrays::Point<1> num_blocks(point_rect.volume());
+  Rect<1> point_rect(input.domain);
+  Point<1> num_blocks(point_rect.volume());
   default_decompose_points<1>(point_rect, procs,
 			      num_blocks, false/*recurse*/,
 			      stealing_enabled, output.slices);  

--- a/src/tasks/reduce_add.cc
+++ b/src/tasks/reduce_add.cc
@@ -45,5 +45,5 @@ void Add::fold<false>(RHS &rhs1, RHS rhs2)
 }
 
 void Add::register_operator() {
-  HighLevelRuntime::register_reduction_op<Add>(REDOP_ADD);
+  Runtime::register_reduction_op<Add>(REDOP_ADD);
 }

--- a/src/tasks/scale_matrix.cc
+++ b/src/tasks/scale_matrix.cc
@@ -19,14 +19,11 @@ ScaleMatrixTask::ScaleMatrixTask(Domain domain,
 
 void ScaleMatrixTask::register_tasks(void)
 {
-  TASKID = Runtime::register_legion_task
-    <ScaleMatrixTask::cpu_task>(AUTO_GENERATE_ID,
-			       Processor::LOC_PROC, 
-			       false,
-			       true,
-			       AUTO_GENERATE_ID,
-			       TaskConfigOptions(true/*leaf*/),
-			       "Scale_Matrix");
+  TASKID = Runtime::generate_static_task_id();
+  TaskVariantRegistrar registrar(TASKID, "Scale_Matrix");
+  registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+  registrar.set_leaf(true);
+  Runtime::preregister_task_variant<ScaleMatrixTask::cpu_task>(registrar, "cpu");
 
 #ifdef SHOW_REGISTER_TASKS
   printf("Register task %d : Scale_Matrix\n", TASKID);

--- a/src/tasks/scale_matrix.cc
+++ b/src/tasks/scale_matrix.cc
@@ -19,7 +19,7 @@ ScaleMatrixTask::ScaleMatrixTask(Domain domain,
 
 void ScaleMatrixTask::register_tasks(void)
 {
-  TASKID = HighLevelRuntime::register_legion_task
+  TASKID = Runtime::register_legion_task
     <ScaleMatrixTask::cpu_task>(AUTO_GENERATE_ID,
 			       Processor::LOC_PROC, 
 			       false,
@@ -35,13 +35,13 @@ void ScaleMatrixTask::register_tasks(void)
 
 void ScaleMatrixTask::cpu_task(const Task *task,
 			      const std::vector<PhysicalRegion> &regions,
-			      Context ctx, HighLevelRuntime *runtime) {
+			      Context ctx, Runtime *runtime) {
 
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);
   assert(task->arglen == sizeof(TaskArgs));
 
-  Point<1> p = task->index_point.get_point<1>();
+  Point<1> p(task->index_point);
   //printf("point = %d\n", p[0]);
 
   log_solver_tasks.print("Inside scale matrix tasks.");

--- a/src/tasks/scale_matrix.cc
+++ b/src/tasks/scale_matrix.cc
@@ -50,7 +50,7 @@ void ScaleMatrixTask::cpu_task(const Task *task,
 
   int rlo = (p[0]) * rblk;
   int rhi = (p[0] + 1) * rblk;
-  PtrMatrix A = get_raw_pointer(regions[0], rlo, rhi, 0, cols);
+  PtrMatrix A = get_raw_pointer<LEGION_READ_WRITE>(regions[0], rlo, rhi, 0, cols);
   A.scale(alpha);
   //A.display("After scaling");
 }

--- a/src/tasks/solver_tasks.cc
+++ b/src/tasks/solver_tasks.cc
@@ -127,9 +127,9 @@ void register_solver_tasks() {
   GemmBroTask::register_tasks();
   Add::register_operator();
 #if 1
-  Runtime::set_registration_callback(create_projector);
+  Runtime::add_registration_callback(create_projector);
 #else
-  //Runtime::set_registration_callback(create_solver_mapper);
-  Runtime::set_registration_callback(create_random_mapper);
+  //Runtime::add_registration_callback(create_solver_mapper);
+  Runtime::add_registration_callback(create_random_mapper);
 #endif
 }

--- a/src/tasks/solver_tasks.cc
+++ b/src/tasks/solver_tasks.cc
@@ -1,6 +1,6 @@
 #include "solver_tasks.hpp"
 
-void create_solver_mapper(Machine machine, HighLevelRuntime *rt,
+void create_solver_mapper(Machine machine, Runtime *rt,
 			  const std::set<Processor> &local_procs) {
 
   create_projector(machine, rt, local_procs);
@@ -52,7 +52,7 @@ void create_solver_mapper(Machine machine, HighLevelRuntime *rt,
   }
 }
 
-void create_random_mapper(Machine machine, HighLevelRuntime *rt,
+void create_random_mapper(Machine machine, Runtime *rt,
 			  const std::set<Processor> &local_procs) {
 
   create_projector(machine, rt, local_procs);
@@ -104,7 +104,7 @@ void create_random_mapper(Machine machine, HighLevelRuntime *rt,
   }
 }
 
-void create_projector(Machine machine, HighLevelRuntime *rt,
+void create_projector(Machine machine, Runtime *rt,
 			   const std::set<Processor> &local_procs) {    
   rt->register_projection_functor
     (CONTRACTION, new Contraction(rt));
@@ -127,9 +127,9 @@ void register_solver_tasks() {
   GemmBroTask::register_tasks();
   Add::register_operator();
 #if 1
-  HighLevelRuntime::set_registration_callback(create_projector);
+  Runtime::set_registration_callback(create_projector);
 #else
-  //HighLevelRuntime::set_registration_callback(create_solver_mapper);
-  HighLevelRuntime::set_registration_callback(create_random_mapper);
+  //Runtime::set_registration_callback(create_solver_mapper);
+  Runtime::set_registration_callback(create_random_mapper);
 #endif
 }

--- a/src/tasks/spmd_mapper.cc
+++ b/src/tasks/spmd_mapper.cc
@@ -4,7 +4,7 @@
 
 //Realm::Logger log_solver_mapper("solver_mapper");
 
-SPMDsolverMapper::SPMDsolverMapper(Machine machine, HighLevelRuntime *rt, Processor local,
+SPMDsolverMapper::SPMDsolverMapper(Machine machine, Runtime *rt, Processor local,
 				   std::vector<Processor>* _procs_list,
 				   std::vector<Memory>* _sysmems_list,
 				   std::map<Memory, std::vector<Processor> >* _sysmem_local_procs,

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -10,7 +10,7 @@ void UTree::init(const Matrix& UMat_) {
 }
 
 void UTree::init(int level, const Matrix& UMat_,
-		 Context ctx, HighLevelRuntime *runtime) {
+		 Context ctx, Runtime *runtime) {
   assert(UMat_.rows()>0 && UMat_.cols()>0);
   this->mLevel = level;
   this->UMat   = UMat_;
@@ -22,12 +22,12 @@ void UTree::init(int level, const Matrix& UMat_,
 }
 
 void UTree::init_rhs
-(const Vector& b, Context ctx, HighLevelRuntime *runtime) {
+(const Vector& b, Context ctx, Runtime *runtime) {
   assert(false);
 }
 
 void UTree::init_rhs
-(const Matrix& b, Context ctx, HighLevelRuntime *runtime,
+(const Matrix& b, Context ctx, Runtime *runtime,
  bool wait) {
   assert(b.cols()==1);
   U.init_data(b, ctx, runtime, wait);
@@ -40,7 +40,7 @@ Vector UTree::rhs() {
 }
 
 void UTree::partition
-(int level, Context ctx, HighLevelRuntime *runtime) {
+(int level, Context ctx, Runtime *runtime) {
   // make sure UMat is valid
   assert( UMat.rows() > 0 );
   assert( UMat.cols() > 0 );
@@ -76,7 +76,7 @@ void UTree::partition
 }
 
 void UTree::horizontal_partition
-(int task_level, Context ctx, HighLevelRuntime *runtime) {
+(int task_level, Context ctx, Runtime *runtime) {
 
   // partition data
   U.partition(task_level, ctx, runtime);
@@ -124,11 +124,11 @@ LMatrix& UTree::leaf() {
   return U;
 }
 
-void UTree::clear(Context ctx, HighLevelRuntime* runtime) {
+void UTree::clear(Context ctx, Runtime* runtime) {
   U.clear(ctx, runtime);
 }
 
-Matrix UTree::solution(Context ctx, HighLevelRuntime *runtime) {
+Matrix UTree::solution(Context ctx, Runtime *runtime) {
   Matrix sln(UMat.rows(), nRhs);
   LogicalRegion lr = U.logical_region();
   RegionRequirement req(lr, READ_ONLY, EXCLUSIVE, lr);
@@ -151,7 +151,7 @@ void VTree::init(const Matrix& VMat_) {
 }
 
 void VTree::init(int level, const Matrix& VMat_,
-		 Context ctx, HighLevelRuntime *runtime) {
+		 Context ctx, Runtime *runtime) {
   // make sure VMat is valid
   assert( VMat_.rows() > 0 && VMat_.cols() > 0);
   this->mLevel = level;
@@ -161,7 +161,7 @@ void VTree::init(int level, const Matrix& VMat_,
 }
 
 void VTree::partition
-(int level, Context ctx, HighLevelRuntime *runtime) {
+(int level, Context ctx, Runtime *runtime) {
   // make sure VMat is valid
   assert( VMat.rows() > 0 );
   assert( VMat.cols() > 0 );
@@ -175,7 +175,7 @@ void VTree::partition
 }
 
 void VTree::horizontal_partition
-(int task_level, Context ctx, HighLevelRuntime *runtime) {
+(int task_level, Context ctx, Runtime *runtime) {
   // create partition
   V.partition(task_level, ctx, runtime);
   // initialize region
@@ -196,7 +196,7 @@ LMatrix& VTree::level_new(int i) {
   return V;
 }
 
-void VTree::clear(Context ctx, HighLevelRuntime* runtime) {
+void VTree::clear(Context ctx, Runtime* runtime) {
   V.clear(ctx, runtime);
 }
 
@@ -213,7 +213,7 @@ void KTree::init
 
 void KTree::init
 (int level, const Matrix& UMat_, const Matrix& VMat_,  const Vector& DVec_,
- Context ctx, HighLevelRuntime *runtime) {
+ Context ctx, Runtime *runtime) {
   this->mLevel = level;
   this->UMat  = UMat_;
   this->VMat  = VMat_;
@@ -230,7 +230,7 @@ void KTree::init
 }
 
 void KTree::partition
-(int level, Context ctx, HighLevelRuntime *runtime) {
+(int level, Context ctx, Runtime *runtime) {
   // create region
   int nrow = DVec.rows();
   int nblk = pow(2, UMat.levels());
@@ -245,7 +245,7 @@ void KTree::partition
 }
 
 void KTree::horizontal_partition
-(int task_level, Context ctx, HighLevelRuntime *runtime) {
+(int task_level, Context ctx, Runtime *runtime) {
   // partition region
   K.partition(task_level, ctx, runtime);
   // initialize region
@@ -253,10 +253,10 @@ void KTree::horizontal_partition
 }
 
 void KTree::solve
-(LMatrix& U, LMatrix& V, Context ctx, HighLevelRuntime *runtime) {
+(LMatrix& U, LMatrix& V, Context ctx, Runtime *runtime) {
   K.solve(U, V, ctx, runtime);
 }
 
-void KTree::clear(Context ctx, HighLevelRuntime* runtime) {
+void KTree::clear(Context ctx, Runtime* runtime) {
   K.clear(ctx, runtime);
 }

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -138,7 +138,7 @@ Matrix UTree::solution(Context ctx, Runtime *runtime) {
   PhysicalRegion region = runtime->map_region(ctx, launcher);
   region.wait_until_valid();
  
-  PtrMatrix temp = get_raw_pointer(region, 0, U.rows(), 0, U.cols());
+  PtrMatrix temp = get_raw_pointer<LEGION_READ_WRITE>(region, 0, U.rows(), 0, U.cols());
   for (int j=0; j<nRhs; j++)
     for (int i=0; i<sln.rows(); i++)
       sln(i, j) = temp(i, j);

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -131,7 +131,7 @@ void UTree::clear(Context ctx, Runtime* runtime) {
 Matrix UTree::solution(Context ctx, Runtime *runtime) {
   Matrix sln(UMat.rows(), nRhs);
   LogicalRegion lr = U.logical_region();
-  RegionRequirement req(lr, READ_ONLY, EXCLUSIVE, lr);
+  RegionRequirement req(lr, LEGION_READ_ONLY, LEGION_EXCLUSIVE, lr);
   req.add_field(FIELDID_V);
  
   InlineLauncher launcher(req);

--- a/src/utility.cc
+++ b/src/utility.cc
@@ -7,18 +7,16 @@ bool is_power_of_two(int x) {
 double* region_pointer
 (const PhysicalRegion &region, int rlo, int rhi, int clo, int chi) {
   Rect<2> bounds, subrect;
-  bounds.lo.x[0] = rlo;
-  bounds.hi.x[0] = rhi-1;
-  bounds.lo.x[1] = clo;
-  bounds.hi.x[1] = chi-1;
-  ByteOffset offsets[2];
-  //double *base = region.get_field_accessor(FIELDID_V).template typeify<double>().template raw_rect_ptr<2>(bounds, subrect, offsets);
-  double *base = region.get_field_accessor(FIELDID_V).typeify<double>().raw_rect_ptr<2>(bounds, subrect, offsets);
-  assert(subrect == bounds);
-  assert(offsets[0].offset == sizeof(double));
-  assert(size_t(rhi-rlo) == offsets[1].offset/sizeof(double));
+  bounds.lo[0] = rlo;
+  bounds.hi[0] = rhi-1;
+  bounds.lo[1] = clo;
+  bounds.hi[1] = chi-1;
+  FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  size_t offset[2];
+  double *base = accessor.ptr(bounds, offset, 2);
+  assert(offset[0] == sizeof(double));
 #ifdef DEBUG_POINTERS
-  printf("ptr = %p (%d, %d)\n", base, offsets[0].offset, offsets[1].offset);
+  printf("ptr = %p (%d, %d)\n", base, offset[0], offset[1]);
 #endif
   return base;
 }
@@ -27,27 +25,15 @@ PtrMatrix get_raw_pointer
 (const PhysicalRegion &region, int rlo, int rhi, int clo, int chi,
  bool wait) {
   Rect<2> bounds, subrect;
-  bounds.lo.x[0] = rlo;
-  bounds.hi.x[0] = rhi-1;
-  bounds.lo.x[1] = clo;
-  bounds.hi.x[1] = chi-1;
-  ByteOffset offsets[2];
-  //double *base = region.get_field_accessor(FIELDID_V).template typeify<double>().template raw_rect_ptr<2>(bounds, subrect, offsets);
-  double *base = region.get_field_accessor(FIELDID_V).typeify<double>().raw_rect_ptr<2>(bounds, subrect, offsets);
-#if 0
-  printf("ptr = %p (%d, %d)\n", base, offsets[0].offset, offsets[1].offset);
-#endif
-
-#if 0
-  if (wait) {
-    double *base = region.get_field_accessor(FIELDID_V).typeify<double>().raw_rect_ptr<2>(bounds, subrect, offsets);
-  }
-#endif
-
-  assert(base);
-  assert(subrect == bounds);
-  assert(offsets[0].offset == sizeof(double));
-  int ld = offsets[1].offset/sizeof(double);
+  bounds.lo[0] = rlo;
+  bounds.hi[0] = rhi-1;
+  bounds.lo[1] = clo;
+  bounds.hi[1] = chi-1;
+  FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  size_t offset[2];
+  double *base = accessor.ptr(bounds, offset, 2);
+  assert(offset[0] == sizeof(double));
+  int ld = offset[1]/sizeof(double);
   assert(ld>=rhi-rlo);
   return PtrMatrix(rhi-rlo, chi-clo, ld, base);
 }
@@ -55,19 +41,17 @@ PtrMatrix get_raw_pointer
 PtrMatrix reduction_pointer
 (const PhysicalRegion &region, int rlo, int rhi, int clo, int chi) {
   Rect<2> bounds, subrect;
-  bounds.lo.x[0] = rlo;
-  bounds.hi.x[0] = rhi-1;
-  bounds.lo.x[1] = clo;
-  bounds.hi.x[1] = chi-1;
-  ByteOffset offsets[2];
-  //double *base = region.get_accessor().template typeify<double>().template raw_rect_ptr<2>(bounds, subrect, offsets);
-  double *base = region.get_accessor().typeify<double>().raw_rect_ptr<2>(bounds, subrect, offsets);
-  assert(subrect == bounds);
-  assert(offsets[0].offset == sizeof(double));
-  //assert(size_t(rhi-rlo) == offsets[1].offset/sizeof(double));
+  bounds.lo[0] = rlo;
+  bounds.hi[0] = rhi-1;
+  bounds.lo[1] = clo;
+  bounds.hi[1] = chi-1;
+  FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  size_t offset[2];
+  double *base = accessor.ptr(bounds, offset, 2);
+  assert(offset[0] == sizeof(double));
 #ifdef DEBUG_POINTERS
-  printf("ptr = %p (%d, %d)\n", base, offsets[0].offset, offsets[1].offset);
+  printf("ptr = %p (%d, %d)\n", base, offset[0], offset[1]);
 #endif
-  int ld = offsets[1].offset/sizeof(double);
+  int ld = offset[1]/sizeof(double);
   return PtrMatrix(rhi-rlo, chi-clo, ld, base);
 }

--- a/src/utility.cc
+++ b/src/utility.cc
@@ -11,7 +11,7 @@ double* region_pointer
   bounds.hi[0] = rhi-1;
   bounds.lo[1] = clo;
   bounds.hi[1] = chi-1;
-  FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
   double *base = accessor.ptr(bounds, offset, 2);
   assert(offset[0] == sizeof(double));
@@ -29,7 +29,7 @@ PtrMatrix get_raw_pointer
   bounds.hi[0] = rhi-1;
   bounds.lo[1] = clo;
   bounds.hi[1] = chi-1;
-  FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
   double *base = accessor.ptr(bounds, offset, 2);
   assert(offset[0] == sizeof(double));
@@ -45,7 +45,7 @@ PtrMatrix reduction_pointer
   bounds.hi[0] = rhi-1;
   bounds.lo[1] = clo;
   bounds.hi[1] = chi-1;
-  FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
   double *base = accessor.ptr(bounds, offset, 2);
   assert(offset[0] == sizeof(double));

--- a/src/utility.cc
+++ b/src/utility.cc
@@ -14,9 +14,8 @@ double* region_pointer
   FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
   double *base = accessor.ptr(bounds, offset, 2);
-  assert(offset[0] == sizeof(double));
 #ifdef DEBUG_POINTERS
-  printf("ptr = %p (%d, %d)\n", base, offset[0], offset[1]);
+  printf("ptr = %p (%d, %d)\n", base, offset[0]*sizeof(double), offset[1]*sizeof(double));
 #endif
   return base;
 }
@@ -32,8 +31,7 @@ PtrMatrix get_raw_pointer
   FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
   double *base = accessor.ptr(bounds, offset, 2);
-  assert(offset[0] == sizeof(double));
-  int ld = offset[1]/sizeof(double);
+  int ld = offset[1];
   assert(ld>=rhi-rlo);
   return PtrMatrix(rhi-rlo, chi-clo, ld, base);
 }
@@ -48,10 +46,9 @@ PtrMatrix reduction_pointer
   FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
   double *base = accessor.ptr(bounds, offset, 2);
-  assert(offset[0] == sizeof(double));
 #ifdef DEBUG_POINTERS
-  printf("ptr = %p (%d, %d)\n", base, offset[0], offset[1]);
+  printf("ptr = %p (%d, %d)\n", base, offset[0]*sizeof(double), offset[1]*sizeof(double));
 #endif
-  int ld = offset[1]/sizeof(double);
+  int ld = offset[1];
   return PtrMatrix(rhi-rlo, chi-clo, ld, base);
 }

--- a/src/utility.cc
+++ b/src/utility.cc
@@ -13,7 +13,7 @@ double* region_pointer
   bounds.hi[1] = chi-1;
   FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
-  double *base = accessor.ptr(bounds, offset, 2);
+  double *base = accessor.ptr(bounds, offset);
 #ifdef DEBUG_POINTERS
   printf("ptr = %p (%d, %d)\n", base, offset[0]*sizeof(double), offset[1]*sizeof(double));
 #endif
@@ -30,7 +30,7 @@ PtrMatrix get_raw_pointer
   bounds.hi[1] = chi-1;
   FieldAccessor<PRIVILEGE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
-  double *base = const_cast<double *>(accessor.ptr(bounds, offset, 2));
+  double *base = const_cast<double *>(accessor.ptr(bounds, offset));
   int ld = offset[1];
   assert(ld>=rhi-rlo);
   return PtrMatrix(rhi-rlo, chi-clo, ld, base);
@@ -47,7 +47,7 @@ PtrMatrix reduction_pointer
   bounds.hi[1] = chi-1;
   FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
-  double *base = accessor.ptr(bounds, offset, 2);
+  double *base = accessor.ptr(bounds, offset);
 #ifdef DEBUG_POINTERS
   printf("ptr = %p (%d, %d)\n", base, offset[0]*sizeof(double), offset[1]*sizeof(double));
 #endif

--- a/src/utility.cc
+++ b/src/utility.cc
@@ -1,4 +1,5 @@
 #include "utility.hpp"
+#include "tasks/reduce_add.hpp"
 
 bool is_power_of_two(int x) {
   return (x > 0) && !(x & (x-1));
@@ -45,7 +46,7 @@ PtrMatrix reduction_pointer
   bounds.hi[0] = rhi-1;
   bounds.lo[1] = clo;
   bounds.hi[1] = chi-1;
-  FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  ReductionAccessor<Add,true,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V, REDOP_ADD);
   size_t offset[2];
   double *base = accessor.ptr(bounds, offset);
 #ifdef DEBUG_POINTERS

--- a/src/utility.cc
+++ b/src/utility.cc
@@ -20,21 +20,23 @@ double* region_pointer
   return base;
 }
 
+template<PrivilegeMode PRIVILEGE>
 PtrMatrix get_raw_pointer
-(const PhysicalRegion &region, int rlo, int rhi, int clo, int chi,
- bool wait) {
+(const PhysicalRegion &region, int rlo, int rhi, int clo, int chi) {
   Rect<2> bounds, subrect;
   bounds.lo[0] = rlo;
   bounds.hi[0] = rhi-1;
   bounds.lo[1] = clo;
   bounds.hi[1] = chi-1;
-  FieldAccessor<LEGION_READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
+  FieldAccessor<PRIVILEGE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t> > accessor(region, FIELDID_V);
   size_t offset[2];
-  double *base = accessor.ptr(bounds, offset, 2);
+  double *base = const_cast<double *>(accessor.ptr(bounds, offset, 2));
   int ld = offset[1];
   assert(ld>=rhi-rlo);
   return PtrMatrix(rhi-rlo, chi-clo, ld, base);
 }
+template PtrMatrix get_raw_pointer<LEGION_READ_ONLY>(const PhysicalRegion &, int, int, int, int);
+template PtrMatrix get_raw_pointer<LEGION_READ_WRITE>(const PhysicalRegion &, int, int, int, int);
 
 PtrMatrix reduction_pointer
 (const PhysicalRegion &region, int rlo, int rhi, int clo, int chi) {

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -3,7 +3,7 @@
 
 // legion stuff
 #include "legion.h"
-using namespace LegionRuntime::HighLevel;
+using namespace Legion;
 
 #include "matrix.hpp"  // for Matrix  class
 #include "hmatrix.hpp" // for HMatrix class
@@ -14,19 +14,19 @@ enum {
 
 void test_vector();
 void test_matrix();
-void test_lmatrix_init(Context, HighLevelRuntime*);
-void test_leaf_solve(Context, HighLevelRuntime*);
-void test_gemm_reduce(Context, HighLevelRuntime*);
-void test_gemm_broadcast(Context, HighLevelRuntime*);
-void test_node_solve(Context, HighLevelRuntime*);
-void test_two_level_reduce(Context, HighLevelRuntime*);
-void test_two_level_broadcast(Context, HighLevelRuntime*);
-void test_two_level_node_solve(Context, HighLevelRuntime*);
-void test_solver(int, int, int, Context, HighLevelRuntime*);
+void test_lmatrix_init(Context, Runtime*);
+void test_leaf_solve(Context, Runtime*);
+void test_gemm_reduce(Context, Runtime*);
+void test_gemm_broadcast(Context, Runtime*);
+void test_node_solve(Context, Runtime*);
+void test_two_level_reduce(Context, Runtime*);
+void test_two_level_broadcast(Context, Runtime*);
+void test_two_level_node_solve(Context, Runtime*);
+void test_solver(int, int, int, Context, Runtime*);
 
 void top_level_task(const Task *task,
 		    const std::vector<PhysicalRegion> &regions,
-		    Context ctx, HighLevelRuntime *runtime) {  
+		    Context ctx, Runtime *runtime) {  
 
   std::cout<<"In top_level_task()"<<std::endl;
     
@@ -44,7 +44,7 @@ void top_level_task(const Task *task,
   int rank = 50;
   int treelvl = 3; // assume 8 cores on every machine
   int launchlvl = 3;
-  const InputArgs &command_args = HighLevelRuntime::get_input_args();
+  const InputArgs &command_args = Runtime::get_input_args();
   if (command_args.argc > 1) {
     for (int i = 1; i < command_args.argc; i++) {
       if (!strcmp(command_args.argv[i],"-rank"))
@@ -115,18 +115,18 @@ int main(int argc, char *argv[], char *envp[]) {
   }
   
   // register top level task
-  HighLevelRuntime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
-  HighLevelRuntime::register_legion_task<top_level_task>
+  Runtime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
+  Runtime::register_legion_task<top_level_task>
     (TOP_LEVEL_TASK_ID, Processor::LOC_PROC, true/*single*/, false/*index*/);
 
   // register solver tasks
   register_solver_tasks();
 
   // register mapper
-  HighLevelRuntime::set_registration_callback(registration_callback);
+  Runtime::set_registration_callback(registration_callback);
 
   // start legion master task
-  return HighLevelRuntime::start(argc, argv);
+  return Runtime::start(argc, argv);
 }
 
 void test_vector() {
@@ -213,7 +213,7 @@ void test_matrix() {
   std::cout << "Test for Matrix passed!" << std::endl;
 }
 
-void test_lmatrix_init(Context ctx, HighLevelRuntime *runtime) {
+void test_lmatrix_init(Context ctx, Runtime *runtime) {
 
   int treelvl = 5, launchlvl = 3;
   int base = 3;
@@ -266,7 +266,7 @@ void test_lmatrix_init(Context ctx, HighLevelRuntime *runtime) {
 	      << std::endl;
 }
 
-void test_leaf_solve(Context ctx, HighLevelRuntime *runtime) {
+void test_leaf_solve(Context ctx, Runtime *runtime) {
 
   int level = 3;
   int m = (1<<10)*pow(2, level), n = 10;
@@ -313,7 +313,7 @@ void test_leaf_solve(Context ctx, HighLevelRuntime *runtime) {
   */
 }
 
-void test_gemm_reduce(Context ctx, HighLevelRuntime *runtime) {
+void test_gemm_reduce(Context ctx, Runtime *runtime) {
   int m=16, n=3;
   int nProc = 4;
   int level = 2;
@@ -343,7 +343,7 @@ void test_gemm_reduce(Context ctx, HighLevelRuntime *runtime) {
   }
 }
 
-void test_gemm_broadcast(Context ctx, HighLevelRuntime *runtime) {
+void test_gemm_broadcast(Context ctx, Runtime *runtime) {
   int m=16, n=3;
   int nProc = 8;
   Matrix UMat(m, n), VMat(2*n, n);
@@ -371,7 +371,7 @@ void test_gemm_broadcast(Context ctx, HighLevelRuntime *runtime) {
   }
 }
 
-void test_node_solve(Context ctx, HighLevelRuntime *runtime) {
+void test_node_solve(Context ctx, Runtime *runtime) {
   int level = 2;
   int r = 3;
   int nProc = 2;
@@ -424,7 +424,7 @@ void test_node_solve(Context ctx, HighLevelRuntime *runtime) {
     std::cout << "Test for node solve passed!" << std::endl;
 }
 
-void test_two_level_reduce(Context ctx, HighLevelRuntime *runtime) {
+void test_two_level_reduce(Context ctx, Runtime *runtime) {
   int m=16, n=3;
   int nProc = 4;
   int level = 2;
@@ -455,7 +455,7 @@ void test_two_level_reduce(Context ctx, HighLevelRuntime *runtime) {
   }
 }
 
-void test_two_level_broadcast(Context ctx, HighLevelRuntime *runtime) {
+void test_two_level_broadcast(Context ctx, Runtime *runtime) {
   int m=16, n=3;
   int nProc = 8;
   Matrix UMat(m, n), VMat(2*n, n);
@@ -484,7 +484,7 @@ void test_two_level_broadcast(Context ctx, HighLevelRuntime *runtime) {
   }
 }
 
-void test_two_level_node_solve(Context ctx, HighLevelRuntime *runtime) {
+void test_two_level_node_solve(Context ctx, Runtime *runtime) {
   int level = 2;
   int r = 3;
   int nProc = 2;
@@ -541,7 +541,7 @@ void test_two_level_node_solve(Context ctx, HighLevelRuntime *runtime) {
 }
 //#endif
 
-void test_solver(int rank, int treelvl, int launchlvl, Context ctx, HighLevelRuntime *runtime) {
+void test_solver(int rank, int treelvl, int launchlvl, Context ctx, Runtime *runtime) {
   // The number of processors should be 8 * #machines, i.e., 2^launchlvl
   // and the number of partitioning, i.e., the number of leaf nodes
   // should be 2^treelvl


### PR DESCRIPTION
This change modernizes the Legion code to use the (not-so-new) `Legion` namespace and corresponding `Point`/`Rect` classes. I also updated the accessor code, though it may not pass privilege checks in all cases because I was lazy and used `READ_WRITE` everywhere (except where required to make the test case pass in our CI).